### PR TITLE
Add Material UI requirement and implementation roadmap

### DIFF
--- a/frontend-description/README.md
+++ b/frontend-description/README.md
@@ -20,7 +20,7 @@ Para acelerar la implementación y alinear decisiones técnicas se sugiere parti
 - **Estado del servidor**: TanStack Query (React Query) para manejar caché, revalidación (`stale-while-revalidate`) y estados de carga por dominio.【F:src/index.ts†L91-L115】
 - **Estado global**: Zustand o Redux Toolkit para almacenar autenticación, fecha de cálculo, preferencias de usuario y catálogos reutilizables.【F:src/modules/fecha-calculo/middleware.ts†L9-L21】
 - **HTTP client**: Axios con interceptores que agreguen `Authorization` y `x-user`, manejen retries y centralicen el formateo de errores.【F:src/common/middlewares/error-handler.ts†L3-L16】【F:src/modules/costos/controllers/costos.controller.ts†L63-L202】
-- **UI kit**: Mantener consistencia con un sistema de diseño (Material UI, Chakra o librería interna) permitiendo overrides para respetar la identidad visual de la organización.
+- **UI kit**: Adoptar Material UI (MUI) como base obligatoria del sistema de diseño, definiendo temas y overrides que respeten la identidad visual de la organización y faciliten el reuso de componentes.
 - **Internacionalización**: i18next con namespaces por dominio para habilitar localización temprana.
 - **Testing**: Vitest + React Testing Library para pruebas unitarias/componentes y Cypress para flujos end-to-end críticos.
 

--- a/frontend-description/plan-implementacion/README.md
+++ b/frontend-description/plan-implementacion/README.md
@@ -1,0 +1,16 @@
+# Plan paso a paso para la implementación del frontend
+
+Este plan desglosa la construcción del frontend en iteraciones cortas. Cada paso indica objetivos, entregables y dependencias para asegurar que el equipo avance de forma ordenada aprovechando la documentación existente en `frontend-description/`.
+
+## Mapa de pasos
+
+1. [Preparativos y alineación](./paso-01-preparativos.md)
+2. [Configuración técnica inicial](./paso-02-configuracion-base.md)
+3. [App shell y navegación principal](./paso-03-app-shell.md)
+4. [Módulos de configuración y catálogos](./paso-04-modulos-configuracion.md)
+5. [Operación diaria y procesos transaccionales](./paso-05-operacion-diaria.md)
+6. [Costos, asignaciones y consolidaciones](./paso-06-costos-consolidaciones.md)
+7. [Reportes y analítica](./paso-07-reportes-analitica.md)
+8. [Calidad, despliegue y mejoras continuas](./paso-08-calidad-despliegue.md)
+
+Cada archivo detalla los componentes a construir, los documentos de referencia y los criterios de aceptación que garantizan el éxito del paso.

--- a/frontend-description/plan-implementacion/paso-01-preparativos.md
+++ b/frontend-description/plan-implementacion/paso-01-preparativos.md
@@ -1,0 +1,19 @@
+# Paso 1. Preparativos y alineación
+
+**Objetivo:** Alinear a los equipos de negocio, backend y frontend sobre alcance, prioridades y criterios de éxito antes de escribir código.
+
+## Actividades principales
+- Revisar `frontend-description/system-overview.md`, `ui-ux-guidelines.md` y `frontend-architecture.md` para comprender la visión completa.
+- Identificar stakeholders claves por módulo (Costos, Consumos, Reportes, etc.) y validar expectativas.
+- Definir el backlog inicial y las métricas de éxito (tiempo de respuesta, estados de error, accesibilidad AA).
+- Elegir la variante de Material UI (tema claro/oscuro, densidades) que se adaptará a la identidad visual.
+
+## Entregables
+- Acta de kickoff con alcance confirmado y riesgos iniciales.
+- Lista priorizada de módulos y flujos críticos.
+- Decisión documentada sobre la personalización del tema de Material UI.
+
+## Criterios de aceptación
+- Todos los integrantes comprenden la arquitectura propuesta y el roadmap de alto nivel.
+- Existe un backlog inicial en la herramienta de gestión del proyecto.
+- Se cuenta con un diseño base (tokens de color, tipografía) alineado con Material UI.

--- a/frontend-description/plan-implementacion/paso-02-configuracion-base.md
+++ b/frontend-description/plan-implementacion/paso-02-configuracion-base.md
@@ -1,0 +1,20 @@
+# Paso 2. Configuración técnica inicial
+
+**Objetivo:** Dejar lista la base técnica del proyecto para iniciar el desarrollo con las herramientas definidas.
+
+## Actividades principales
+- Inicializar proyecto con Vite + React + TypeScript y configurar alias de importación.
+- Instalar Material UI (MUI Core y MUI X si se usarán tablas avanzadas) y crear el tema central.
+- Configurar TanStack Query, Zustand/Redux Toolkit y Axios con interceptores de autenticación (`Authorization`, `x-user`).
+- Integrar ESLint, Prettier, Stylelint, Husky y commitlint conforme a la guía de `frontend-description/README.md`.
+- Definir variables de entorno (`VITE_API_URL`, `VITE_DEFAULT_CALCULATION_DATE`, `VITE_VERSION`).
+
+## Entregables
+- Repositorio inicial con pipeline de linting y formateo automático.
+- Tema de Material UI aplicado globalmente (colores, tipografía, componentes base).
+- Instancias de Axios y proveedores de estado configurados.
+
+## Criterios de aceptación
+- Comandos `npm run lint` y `npm run test` configurados aunque las pruebas aún no existan.
+- Se puede hacer render del `App` con el tema de Material UI y providers de React Query y store global.
+- Las variables de entorno cuentan con ejemplos documentados (`.env.example`).

--- a/frontend-description/plan-implementacion/paso-03-app-shell.md
+++ b/frontend-description/plan-implementacion/paso-03-app-shell.md
@@ -1,0 +1,20 @@
+# Paso 3. App shell y navegación principal
+
+**Objetivo:** Construir la estructura persistente de la aplicación que unifica la experiencia de usuario.
+
+## Actividades principales
+- Implementar layout con header, sidebar y área de contenido siguiendo `frontend-architecture.md`.
+- Conectar el selector de fecha de cálculo al servicio (`GET/POST /api/fecha-calculo`) y almacenar el valor en el store global.
+- Configurar React Router v6 con rutas anidadas que sigan la jerarquía descrita en `system-overview.md`.
+- Crear componentes reutilizables de breadcrumbs, toasts y contenedores de página basados en Material UI.
+- Definir la estructura de permisos y estados vacíos comunes.
+
+## Entregables
+- App shell funcional con navegación entre rutas mock.
+- Selector de fecha de cálculo sincronizado y visible en el header.
+- Sistema de notificaciones y breadcrumbs reutilizable.
+
+## Criterios de aceptación
+- El layout responde correctamente en resoluciones desktop y tablet.
+- El cambio de fecha de cálculo dispara eventos o invalidaciones de React Query.
+- El menú lateral resalta la ruta activa y permite colapsar/expandir.

--- a/frontend-description/plan-implementacion/paso-04-modulos-configuracion.md
+++ b/frontend-description/plan-implementacion/paso-04-modulos-configuracion.md
@@ -1,0 +1,20 @@
+# Paso 4. Módulos de configuración y catálogos
+
+**Objetivo:** Implementar los módulos base que alimentan catálogos y parámetros esenciales para el resto del sistema.
+
+## Actividades principales
+- Desarrollar vistas CRUD para Actividades, Empleados, Centros de producción y apoyo, y Fecha de cálculo.
+- Construir formularios reutilizables con validaciones de Material UI y manejo de errores centralizado.
+- Implementar tablas paginadas con filtros persistentes usando componentes de MUI Data Grid o Table.
+- Configurar sincronizaciones y banners informativos para catálogos según `catalogos.md`.
+- Agregar pruebas unitarias de hooks y componentes clave.
+
+## Entregables
+- Rutas de Configuración operativas con datos provenientes de los endpoints reales.
+- Componentes de formulario y tabla reutilizables documentados.
+- Hooks de datos (`useActividades`, `useEmpleados`, etc.) con estados `loading` y `error` gestionados.
+
+## Criterios de aceptación
+- Operaciones CRUD muestran toasts y estados deshabilitados durante requests.
+- Los catálogos se almacenan en cache y se invalidan tras mutaciones.
+- Existe documentación breve de componentes compartidos en Storybook o MDX.

--- a/frontend-description/plan-implementacion/paso-05-operacion-diaria.md
+++ b/frontend-description/plan-implementacion/paso-05-operacion-diaria.md
@@ -1,0 +1,20 @@
+# Paso 5. Operación diaria y procesos transaccionales
+
+**Objetivo:** Cubrir los flujos diarios de captura de información (Consumos, Producciones, Litros, Pérdidas, Sobrantes).
+
+## Actividades principales
+- Implementar filtros por fecha, producto y `accessId` replicando la experiencia descrita en cada documento de módulo.
+- Construir tablas densas con edición inline donde aplique y soporte para importaciones manuales.
+- Integrar indicadores de sincronización y banners según el estado de procesos automáticos.
+- Habilitar cargas masivas con retroalimentación en tiempo real y bitácora de errores.
+- Añadir pruebas de integración con React Testing Library cubriendo escenarios críticos.
+
+## Entregables
+- Módulos de operación diaria conectados a endpoints reales con estados vacíos y mensajes de error consistentes.
+- Componentes reutilizables para manejo de importaciones (`Upload`, `Progress`, `ErrorList`).
+- Documentación de flujos E2E críticos para posterior automatización en Cypress.
+
+## Criterios de aceptación
+- Los listados soportan paginación, ordenamiento y exportación cuando corresponda.
+- Los formularios evitan envíos duplicados y muestran validaciones inline.
+- Los procesos de importación actualizan automáticamente los módulos relacionados tras completarse.

--- a/frontend-description/plan-implementacion/paso-06-costos-consolidaciones.md
+++ b/frontend-description/plan-implementacion/paso-06-costos-consolidaciones.md
@@ -1,0 +1,20 @@
+# Paso 6. Costos, asignaciones y consolidaciones
+
+**Objetivo:** Implementar los módulos que calculan, distribuyen y consolidan costos asegurando trazabilidad.
+
+## Actividades principales
+- Construir vistas maestro-detalle para Costos, CIF, Asignaciones y Existencias siguiendo `costos.md`, `cif.md` y `existencias.md`.
+- Implementar visualizaciones de balances (`debitos`, `creditos`, `balance`) con componentes de Material UI.
+- Habilitar procesos de prorrateo y consolidación con diálogos de confirmación y seguimiento de progreso.
+- Conectar bitácoras e históricos para auditar `x-user`, `createdAt`, `updatedAt`.
+- Añadir pruebas unitarias para lógica de transformación y cálculos presentados al usuario.
+
+## Entregables
+- Módulos de Costos y consolidaciones funcionales con manejo de estados de proceso (en ejecución, completado, error).
+- Componentes reutilizables para indicadores de balance y timeline de auditoría.
+- Documentación de dependencias entre módulos y triggers de sincronización.
+
+## Criterios de aceptación
+- Las operaciones largas muestran feedback persistente y permiten reintentos controlados.
+- Los datos clave se presentan con formato de moneda y porcentajes consistentes.
+- La navegación entre Costos, Existencias y Asientos está enlazada mediante deep-linking.

--- a/frontend-description/plan-implementacion/paso-07-reportes-analitica.md
+++ b/frontend-description/plan-implementacion/paso-07-reportes-analitica.md
@@ -1,0 +1,20 @@
+# Paso 7. Reportes y analítica
+
+**Objetivo:** Entregar las vistas de consulta y descarga de información consolidada.
+
+## Actividades principales
+- Implementar filtros avanzados con persistencia en URL y sincronización con TanStack Query.
+- Construir tablas y gráficos basados en Material UI y librerías compatibles (Recharts, Nivo) respetando el tema definido.
+- Habilitar exportaciones (`csv`, `xlsx`) reutilizando la lógica definida en `reportes.md` y servicios asociados.
+- Añadir indicadores de rendimiento y mensajes de estados vacíos contextualizados.
+- Documentar los flujos de reportes en guías rápidas para usuarios finales.
+
+## Entregables
+- Vistas de reportes con carga independiente por módulo y componentes reutilizables de filtros.
+- Mecanismo de exportación parametrizable con manejo de errores y seguimiento de progreso.
+- Documentación de soporte que explique cómo interpretar los reportes disponibles.
+
+## Criterios de aceptación
+- Los filtros se pueden compartir mediante la URL (deep-linking).
+- Las descargas respetan permisos y muestran confirmaciones al finalizar.
+- Los gráficos mantienen accesibilidad (descripciones, etiquetas, colores con contraste suficiente).

--- a/frontend-description/plan-implementacion/paso-08-calidad-despliegue.md
+++ b/frontend-description/plan-implementacion/paso-08-calidad-despliegue.md
@@ -1,0 +1,20 @@
+# Paso 8. Calidad, despliegue y mejoras continuas
+
+**Objetivo:** Garantizar la estabilidad del frontend y preparar el lanzamiento controlado.
+
+## Actividades principales
+- Implementar pruebas E2E con Cypress para los flujos definidos en pasos anteriores.
+- Configurar pipelines de CI/CD que ejecuten lint, pruebas unitarias, pruebas E2E y build de producción.
+- Realizar auditorías de accesibilidad (Lighthouse, axe) y rendimiento (Core Web Vitals).
+- Preparar documentación de usuario final con capturas de pantalla y tutoriales.
+- Planificar la retroalimentación posterior al lanzamiento y el backlog de mejoras continuas.
+
+## Entregables
+- Dashboard de CI/CD con build verde y reportes de pruebas.
+- Informe de accesibilidad y rendimiento con acciones de mejora.
+- Manual de usuario y plan de soporte post-lanzamiento.
+
+## Criterios de aceptación
+- El build de producción se despliega en un entorno de staging listo para pruebas de aceptación.
+- Todas las métricas críticas se encuentran dentro de los umbrales definidos (performance, accesibilidad, estabilidad).
+- Existe un plan de mantenimiento y monitoreo continuo.


### PR DESCRIPTION
## Summary
- specify Material UI as the required design system for the frontend stack
- add a step-by-step implementation plan outlining deliverables and acceptance criteria for each phase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e351d812a88330836d326731c340de