### PR TITLE
Refine configuracion catalog layout and API integration

### DIFF
--- a/frontend-app/src/lib/http/apiClient.ts
+++ b/frontend-app/src/lib/http/apiClient.ts
@@ -13,7 +13,8 @@ async function request<TResponse, TBody = unknown>(
   url: string,
   options: RequestOptions<TBody> = {}
 ): Promise<TResponse> {
-  const baseUrl = import.meta.env?.VITE_API_URL ?? '';
+  const rawBaseUrl = import.meta.env?.VITE_API_URL;
+  const baseUrl = (rawBaseUrl ?? 'http://localhost:3000').replace(/\/$/, '');
   const controller = new AbortController();
   const signal = options.signal ?? controller.signal;
 

--- a/frontend-app/src/modules/configuracion/components/CatalogFilterBar.tsx
+++ b/frontend-app/src/modules/configuracion/components/CatalogFilterBar.tsx
@@ -6,6 +6,9 @@ interface CatalogFilterBarProps {
   value: CatalogFilterState;
   onChange: (value: CatalogFilterState) => void;
   disabled?: boolean;
+  searchPlaceholder?: string;
+  hideStatus?: boolean;
+  hideUpdatedBy?: boolean;
 }
 
 const statusOptions: Array<{ value: CatalogFilterState['status']; label: string }> = [
@@ -15,7 +18,14 @@ const statusOptions: Array<{ value: CatalogFilterState['status']; label: string 
   { value: 'sincronizando', label: 'Sincronizando' },
 ];
 
-const CatalogFilterBar: React.FC<CatalogFilterBarProps> = ({ value, onChange, disabled }) => (
+const CatalogFilterBar: React.FC<CatalogFilterBarProps> = ({
+  value,
+  onChange,
+  disabled,
+  searchPlaceholder,
+  hideStatus,
+  hideUpdatedBy,
+}) => (
   <div className="config-filter-bar" role="search">
     <div className="config-filter-bar__field">
       <label htmlFor="catalog-search" className="config-field-label">
@@ -24,43 +34,47 @@ const CatalogFilterBar: React.FC<CatalogFilterBarProps> = ({ value, onChange, di
       <input
         id="catalog-search"
         className="config-input"
-        placeholder="Buscar por nombre o código"
+        placeholder={searchPlaceholder ?? 'Buscar por nombre o código'}
         value={value.search}
         onChange={(event) => onChange({ ...value, search: event.target.value })}
         disabled={disabled}
       />
     </div>
-    <div className="config-filter-bar__field">
-      <label htmlFor="catalog-status" className="config-field-label">
-        Estado
-      </label>
-      <select
-        id="catalog-status"
-        className="config-select"
-        value={value.status}
-        onChange={(event) => onChange({ ...value, status: event.target.value as CatalogFilterState['status'] })}
-        disabled={disabled}
-      >
-        {statusOptions.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </div>
-    <div className="config-filter-bar__field">
-      <label htmlFor="catalog-updated-by" className="config-field-label">
-        Último cambio por
-      </label>
-      <input
-        id="catalog-updated-by"
-        className="config-input"
-        placeholder="Usuario"
-        value={value.updatedBy ?? ''}
-        onChange={(event) => onChange({ ...value, updatedBy: event.target.value || undefined })}
-        disabled={disabled}
-      />
-    </div>
+    {!hideStatus && (
+      <div className="config-filter-bar__field">
+        <label htmlFor="catalog-status" className="config-field-label">
+          Estado
+        </label>
+        <select
+          id="catalog-status"
+          className="config-select"
+          value={value.status ?? 'todos'}
+          onChange={(event) => onChange({ ...value, status: event.target.value as CatalogFilterState['status'] })}
+          disabled={disabled}
+        >
+          {statusOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    )}
+    {!hideUpdatedBy && (
+      <div className="config-filter-bar__field">
+        <label htmlFor="catalog-updated-by" className="config-field-label">
+          Último cambio por
+        </label>
+        <input
+          id="catalog-updated-by"
+          className="config-input"
+          placeholder="Usuario"
+          value={value.updatedBy ?? ''}
+          onChange={(event) => onChange({ ...value, updatedBy: event.target.value || undefined })}
+          disabled={disabled}
+        />
+      </div>
+    )}
   </div>
 );
 

--- a/frontend-app/src/modules/configuracion/components/ConfigNavBar.tsx
+++ b/frontend-app/src/modules/configuracion/components/ConfigNavBar.tsx
@@ -7,17 +7,20 @@ const ConfigNavBar: React.FC = () => {
 
   return (
     <nav className="config-nav" aria-label="Navegación secundaria">
-      {routes.map((route) => (
-        <button
-          key={route.id}
-          type="button"
-          className={`config-nav__item ${activeRoute?.id === route.id ? 'config-nav__item--active' : ''}`}
-          onClick={() => selectRoute(route.id)}
-          aria-current={activeRoute?.id === route.id ? 'page' : undefined}
-        >
-          {route.meta.secondaryNavLabel ?? route.meta.title}
-        </button>
-      ))}
+      <ul className="config-nav__list">
+        {routes.map((route) => (
+          <li key={route.id}>
+            <button
+              type="button"
+              className={`config-nav__item ${activeRoute?.id === route.id ? 'config-nav__item--active' : ''}`}
+              onClick={() => selectRoute(route.id)}
+              aria-current={activeRoute?.id === route.id ? 'page' : undefined}
+            >
+              {route.meta.secondaryNavLabel ?? route.meta.title}
+            </button>
+          </li>
+        ))}
+      </ul>
     </nav>
   );
 };

--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -29,59 +29,54 @@
 }
 
 .config-nav {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   background: #ffffff;
-  padding: 20px;
-  border-radius: 24px;
+  border-radius: 20px;
   border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  padding: 4px 16px;
+}
+
+.config-nav__list {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-x: auto;
+}
+
+.config-nav__list > li {
+  display: flex;
 }
 
 .config-nav__item {
-  border: 1px solid transparent;
-  border-radius: 16px;
-  background: linear-gradient(145deg, #f8fafc 0%, #ffffff 100%);
-  padding: 14px 18px;
+  border: none;
+  border-bottom: 3px solid transparent;
+  border-radius: 12px 12px 0 0;
+  background: transparent;
+  padding: 14px 20px;
   font-weight: 600;
-  color: #1f2937;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  color: #475569;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.config-nav__item::after {
-  content: '→';
-  font-size: 0.9rem;
-  opacity: 0;
-  transform: translateX(-6px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .config-nav__item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.14);
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.08);
 }
 
-.config-nav__item:hover::after {
-  opacity: 1;
-  transform: translateX(0);
+.config-nav__item:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .config-nav__item--active {
-  border-color: rgba(37, 99, 235, 0.45);
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(125, 211, 252, 0.12));
-  color: #1d4ed8;
-  box-shadow: 0 20px 35px rgba(37, 99, 235, 0.18);
-}
-
-.config-nav__item--active::after {
-  opacity: 1;
-  transform: translateX(0);
+  color: #1e3a8a;
+  border-bottom-color: #2563eb;
+  background: rgba(37, 99, 235, 0.14);
 }
 
 .config-section {
@@ -266,6 +261,68 @@ textarea.config-input {
   gap: 10px;
 }
 
+.catalog-view {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.catalog-view__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.catalog-view__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  background: #ffffff;
+  border-radius: 24px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  padding: 20px 24px;
+}
+
+.catalog-view__header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.catalog-view__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.catalog-view__subtitle {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.catalog-view__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.catalog-view__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.12);
+  padding: 6px 12px;
+  border-radius: 9999px;
+}
+
 .config-table {
   width: 100%;
   border-collapse: separate;
@@ -362,11 +419,34 @@ textarea.config-input {
 }
 
 .config-alert {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
   padding: 12px 16px;
   border-radius: 16px;
   border: 1px solid rgba(220, 38, 38, 0.35);
   background: rgba(254, 226, 226, 0.92);
   color: #991b1b;
+}
+
+.config-alert__action {
+  background: none;
+  border: none;
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.config-alert__action:hover {
+  opacity: 0.85;
+}
+
+.config-alert__action:focus-visible {
+  outline: 2px solid rgba(220, 38, 38, 0.55);
+  outline-offset: 2px;
 }
 
 .toast-viewport {

--- a/frontend-app/src/modules/configuracion/hooks/useActividades.ts
+++ b/frontend-app/src/modules/configuracion/hooks/useActividades.ts
@@ -1,11 +1,18 @@
-import type { CatalogEntityBase } from '../types';
 import { useCatalogData } from './useCatalogData';
 
-export interface Actividad extends CatalogEntityBase {
-  descripcion: string;
-  responsable: string;
+export interface Actividad {
+  id: string;
+  nombre: string;
+  nroAct: number;
 }
 
+const mapActividad = (actividad: any): Actividad => ({
+  id: actividad?._id ? String(actividad._id) : String(actividad?.id ?? ''),
+  nombre: actividad?.nombre ?? '',
+  nroAct: Number(actividad?.nroAct ?? 0),
+});
+
 export function useActividades() {
-  return useCatalogData<Actividad>({ resource: 'actividades' });
+  return useCatalogData<Actividad>({ resource: 'actividades', mapResponse: mapActividad });
 }
+

--- a/frontend-app/src/modules/configuracion/hooks/useCentros.ts
+++ b/frontend-app/src/modules/configuracion/hooks/useCentros.ts
@@ -1,11 +1,17 @@
-import type { CatalogEntityBase } from '../types';
 import { useCatalogData } from './useCatalogData';
 
-export interface Centro extends CatalogEntityBase {
-  codigo: string;
-  tipo: 'produccion' | 'apoyo';
+export interface Centro {
+  id: string;
+  nombre: string;
+  nroCentro: number;
 }
 
+const mapCentro = (centro: any): Centro => ({
+  id: centro?._id ? String(centro._id) : String(centro?.id ?? ''),
+  nombre: centro?.nombre ?? '',
+  nroCentro: Number(centro?.nroCentro ?? 0),
+});
+
 export function useCentros() {
-  return useCatalogData<Centro>({ resource: 'centros' });
+  return useCatalogData<Centro>({ resource: 'centros-produccion', mapResponse: mapCentro });
 }

--- a/frontend-app/src/modules/configuracion/hooks/useEmpleados.ts
+++ b/frontend-app/src/modules/configuracion/hooks/useEmpleados.ts
@@ -1,11 +1,17 @@
-import type { CatalogEntityBase } from '../types';
 import { useCatalogData } from './useCatalogData';
 
-export interface Empleado extends CatalogEntityBase {
-  correo: string;
-  centroAsignado: string;
+export interface Empleado {
+  id: string;
+  nombre: string;
+  nroEmpleado: number;
 }
 
+const mapEmpleado = (empleado: any): Empleado => ({
+  id: empleado?._id ? String(empleado._id) : String(empleado?.id ?? ''),
+  nombre: empleado?.nombre ?? '',
+  nroEmpleado: Number(empleado?.Nroem ?? empleado?.nroEmpleado ?? 0),
+});
+
 export function useEmpleados() {
-  return useCatalogData<Empleado>({ resource: 'empleados' });
+  return useCatalogData<Empleado>({ resource: 'empleados', mapResponse: mapEmpleado });
 }

--- a/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
@@ -2,19 +2,15 @@ import React, { useMemo, useState } from 'react';
 import CatalogFilterBar from '../components/CatalogFilterBar';
 import CatalogTable from '../components/CatalogTable';
 import type { CatalogTableColumn } from '../components/CatalogTable';
-import EntityStatusBadge from '../components/EntityStatusBadge';
 import FormActions from '../components/FormActions';
 import FormSection from '../components/FormSection';
 import ProtectedRoute from '../components/ProtectedRoute';
 import { useConfigContext } from '../context/ConfigContext';
 import { useToast } from '../context/ToastContext';
-import { useActividades } from '../hooks/useActividades';
+import { useActividades, type Actividad } from '../hooks/useActividades';
 import { useForm } from '../hooks/useForm';
 import type { CatalogFilterState } from '../types';
-import {
-  actividadValidator,
-  defaultActividadValues,
-} from '../schemas/actividadSchema';
+import { actividadValidator, defaultActividadValues } from '../schemas/actividadSchema';
 import type { ActividadFormValues } from '../schemas/actividadSchema';
 
 const ActividadesPage: React.FC = () => {
@@ -22,136 +18,133 @@ const ActividadesPage: React.FC = () => {
   const catalog = useActividades();
   const { showToast } = useToast();
   const [filters, setFilters] = useState<CatalogFilterState>({ search: '', status: 'todos' });
+  const [isFormOpen, setIsFormOpen] = useState(false);
   const form = useForm<ActividadFormValues>({ defaultValues: defaultActividadValues, validator: actividadValidator });
 
-  const filteredItems = useMemo(() => {
-    return catalog.items.filter((item) => {
-      const matchesSearch = `${item.nombre} ${item.descripcion}`
-        .toLowerCase()
-        .includes(filters.search.toLowerCase());
-      const matchesStatus = filters.status === 'todos' || item.estado === filters.status;
-      const matchesUser = !filters.updatedBy || item.audit.updatedBy?.includes(filters.updatedBy);
-      return matchesSearch && matchesStatus && matchesUser;
-    });
-  }, [catalog.items, filters]);
+  const actividades = useMemo<Actividad[]>(() => {
+    const searchTerm = filters.search.trim().toLowerCase();
+    const ordered = [...catalog.items].sort((a, b) => a.nroAct - b.nroAct);
 
-  const columns: CatalogTableColumn<(typeof filteredItems)[number]>[] = [
+    if (!searchTerm) {
+      return ordered;
+    }
+
+    return ordered.filter((actividad) =>
+      `${actividad.nroAct} ${actividad.nombre}`.toLowerCase().includes(searchTerm),
+    );
+  }, [catalog.items, filters.search]);
+
+  const columns: CatalogTableColumn<Actividad>[] = [
+    {
+      key: 'nroAct',
+      label: 'N° de actividad',
+      width: '160px',
+      render: (actividad) => actividad.nroAct.toString().padStart(3, '0'),
+    },
     { key: 'nombre', label: 'Nombre' },
-    { key: 'descripcion', label: 'Descripción' },
-    {
-      key: 'estado',
-      label: 'Estado',
-      render: (actividad) => <EntityStatusBadge status={actividad.estado} reason={actividad.audit.changeReason} />,
-    },
-    {
-      key: 'audit',
-      label: 'Última modificación',
-      render: (actividad) => (
-        <span className="audit-meta">
-          {actividad.audit.updatedAt} — {actividad.audit.updatedBy ?? actividad.audit.createdBy}
-        </span>
-      ),
-    },
   ];
+
+  const handleFiltersChange = (next: CatalogFilterState) =>
+    setFilters({ search: next.search, status: 'todos', updatedBy: undefined });
 
   const handleSubmit = form.handleSubmit(async (values: ActividadFormValues) => {
     try {
-      await catalog.create({
-        nombre: values.nombre,
-        descripcion: values.descripcion,
-        estado: values.estado,
-        responsable: values.responsable,
-        audit: {
-          createdAt: new Date().toISOString(),
-          createdBy: 'usuario.actual',
-          updatedAt: new Date().toISOString(),
-          updatedBy: 'usuario.actual',
-          changeReason: 'Alta manual',
-        },
-        id: '',
-      });
-      form.reset();
+      await catalog.create({ nombre: values.nombre.trim() });
       showToast('Actividad creada correctamente.', 'success');
+      form.reset();
+      setIsFormOpen(false);
     } catch (error) {
       showToast('No se pudo crear la actividad. Intenta nuevamente.', 'error');
     }
   });
 
+  const toggleButtonClassName = `config-button ${
+    isFormOpen ? 'config-button--ghost' : 'config-button--primary'
+  }`;
+
   return (
-    <div>
-      <ProtectedRoute permissions={[activeRoute?.meta.permissions.write ?? 'catalogos.write']}>
-        <FormSection
-          title="Registrar nueva actividad"
-          description="Completa los campos obligatorios para sincronizar la actividad con producción y consumos."
-        >
-          <form onSubmit={handleSubmit} noValidate className="config-form">
-            <div className="config-form-field">
-              <label htmlFor="actividad-nombre" className="config-field-label">
-                Nombre de la actividad
-              </label>
-              <input id="actividad-nombre" className="config-input" {...form.register('nombre')} />
-              {form.formState.errors.nombre && <p className="config-field-error">{form.formState.errors.nombre}</p>}
-            </div>
+    <div className="catalog-view">
+      <section className="catalog-view__panel">
+        <header className="catalog-view__header">
+          <div className="catalog-view__header-text">
+            <h2 className="catalog-view__title">Actividades registradas</h2>
+            <p className="catalog-view__subtitle">
+              Administra las actividades productivas que participan en los prorrateos.
+            </p>
+          </div>
+          <div className="catalog-view__actions">
+            <span className="catalog-view__meta">{catalog.items.length} en total</span>
+            <button
+              type="button"
+              className={toggleButtonClassName}
+              onClick={() => setIsFormOpen((open) => !open)}
+              aria-expanded={isFormOpen}
+              aria-controls="actividad-form"
+            >
+              {isFormOpen ? 'Cerrar formulario' : 'Nueva actividad'}
+            </button>
+          </div>
+        </header>
 
-            <div className="config-form-field config-form-field--full">
-              <label htmlFor="actividad-descripcion" className="config-field-label">
-                Descripción operativa
-              </label>
-              <textarea
-                id="actividad-descripcion"
-                className="config-input"
-                rows={3}
-                value={form.formState.values.descripcion}
-                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
-                  form.setValue('descripcion', event.target.value)
-                }
+        <CatalogFilterBar
+          value={filters}
+          onChange={handleFiltersChange}
+          disabled={catalog.isLoading}
+          hideStatus
+          hideUpdatedBy
+          searchPlaceholder="Buscar por nombre o número"
+        />
+
+        {catalog.error && (
+          <div className="config-alert" role="alert">
+            <span>No pudimos cargar las actividades. Intenta nuevamente.</span>
+            <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        <CatalogTable
+          rows={actividades}
+          columns={columns}
+          loading={catalog.isLoading}
+          emptyMessage="No hay actividades registradas."
+        />
+      </section>
+
+      {isFormOpen && (
+        <ProtectedRoute permissions={[activeRoute?.meta.permissions.write ?? 'catalogos.write']}>
+          <FormSection
+            title="Crear actividad"
+            description="El número de actividad se asigna automáticamente al guardar."
+          >
+            <form id="actividad-form" onSubmit={handleSubmit} noValidate className="config-form">
+              <div className="config-form-field">
+                <label htmlFor="actividad-nombre" className="config-field-label">
+                  Nombre de la actividad
+                </label>
+                <input
+                  id="actividad-nombre"
+                  className="config-input"
+                  maxLength={120}
+                  {...form.register('nombre')}
+                />
+                {form.formState.errors.nombre && (
+                  <p className="config-field-error">{form.formState.errors.nombre}</p>
+                )}
+              </div>
+
+              <FormActions
+                isSubmitting={form.formState.isSubmitting}
+                onCancel={() => {
+                  form.reset();
+                  setIsFormOpen(false);
+                }}
               />
-              {form.formState.errors.descripcion && (
-                <p className="config-field-error">{form.formState.errors.descripcion}</p>
-              )}
-            </div>
-
-            <div className="config-form-field">
-              <label htmlFor="actividad-responsable" className="config-field-label">
-                Responsable
-              </label>
-              <input id="actividad-responsable" className="config-input" {...form.register('responsable')} />
-              {form.formState.errors.responsable && (
-                <p className="config-field-error">{form.formState.errors.responsable}</p>
-              )}
-            </div>
-
-            <div className="config-form-field">
-              <label htmlFor="actividad-estado" className="config-field-label">
-                Estado
-              </label>
-              <select
-                id="actividad-estado"
-                className="config-select"
-                value={form.formState.values.estado}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  form.setValue('estado', event.target.value as ActividadFormValues['estado'])
-                }
-              >
-                <option value="activo">Activo</option>
-                <option value="inactivo">Inactivo</option>
-                <option value="sincronizando">Sincronizando</option>
-              </select>
-            </div>
-
-            <FormActions isSubmitting={form.formState.isSubmitting} onCancel={() => form.reset()} />
-          </form>
-        </FormSection>
-      </ProtectedRoute>
-
-      <CatalogFilterBar value={filters} onChange={setFilters} disabled={catalog.isLoading} />
-
-      <CatalogTable
-        rows={filteredItems}
-        columns={columns}
-        loading={catalog.isLoading}
-        emptyMessage="No hay actividades registradas."
-      />
+            </form>
+          </FormSection>
+        </ProtectedRoute>
+      )}
     </div>
   );
 };

--- a/frontend-app/src/modules/configuracion/schemas/actividadSchema.ts
+++ b/frontend-app/src/modules/configuracion/schemas/actividadSchema.ts
@@ -1,47 +1,30 @@
-import type { CatalogEntityStatus } from '../types';
 import type { ValidationIssue, ValidationResult, Validator } from './types';
 
 export interface ActividadFormValues {
   nombre: string;
-  descripcion: string;
-  estado: CatalogEntityStatus;
-  responsable: string;
 }
 
 export const defaultActividadValues: ActividadFormValues = {
   nombre: '',
-  descripcion: '',
-  estado: 'activo',
-  responsable: '',
 };
-
-const validStatuses: CatalogEntityStatus[] = ['activo', 'inactivo', 'sincronizando'];
 
 export const actividadValidator: Validator<ActividadFormValues> = (input) => {
   const values = { ...defaultActividadValues, ...(input as Partial<ActividadFormValues>) };
   const issues: ValidationIssue[] = [];
 
-  if (!values.nombre || values.nombre.trim().length < 3) {
-    issues.push({ path: 'nombre', message: 'El nombre debe tener al menos 3 caracteres.' });
-  }
+  const nombre = values.nombre.trim();
 
-  if (!values.descripcion || values.descripcion.trim().length < 10) {
-    issues.push({ path: 'descripcion', message: 'Describe la actividad con al menos 10 caracteres.' });
-  }
-
-  if (!validStatuses.includes(values.estado)) {
-    issues.push({ path: 'estado', message: 'Estado no válido.' });
-  }
-
-  if (!values.responsable) {
-    issues.push({ path: 'responsable', message: 'Debes asignar un responsable funcional.' });
+  if (!nombre) {
+    issues.push({ path: 'nombre', message: 'El nombre de la actividad es obligatorio.' });
+  } else if (nombre.length < 3) {
+    issues.push({ path: 'nombre', message: 'Ingresa al menos 3 caracteres.' });
   }
 
   if (issues.length) {
     return { success: false, issues };
   }
 
-  return { success: true, data: values } satisfies ValidationResult<ActividadFormValues>;
+  return { success: true, data: { nombre } } satisfies ValidationResult<ActividadFormValues>;
 };
 
 export type ActividadValidationResult = ValidationResult<ActividadFormValues>;

--- a/frontend-app/src/modules/configuracion/schemas/centroSchema.ts
+++ b/frontend-app/src/modules/configuracion/schemas/centroSchema.ts
@@ -1,42 +1,38 @@
 import type { ValidationIssue, ValidationResult, Validator } from './types';
 
 export interface CentroFormValues {
-  codigo: string;
   nombre: string;
-  tipo: 'produccion' | 'apoyo';
-  responsable: string;
+  nroCentro: string;
 }
 
 export const defaultCentroValues: CentroFormValues = {
-  codigo: '',
   nombre: '',
-  tipo: 'produccion',
-  responsable: '',
+  nroCentro: '',
 };
 
 export const centroValidator: Validator<CentroFormValues> = (input) => {
   const values = { ...defaultCentroValues, ...(input as Partial<CentroFormValues>) };
   const issues: ValidationIssue[] = [];
 
-  if (!values.codigo || values.codigo.trim().length < 2) {
-    issues.push({ path: 'codigo', message: 'El código debe tener al menos 2 caracteres.' });
+  const nroCentro = values.nroCentro.trim();
+  const nombre = values.nombre.trim();
+  const parsedNumber = Number(nroCentro);
+
+  if (!nroCentro) {
+    issues.push({ path: 'nroCentro', message: 'Ingresa el número de centro.' });
+  } else if (!Number.isInteger(parsedNumber) || parsedNumber <= 0) {
+    issues.push({ path: 'nroCentro', message: 'El número debe ser un entero positivo.' });
   }
 
-  if (!values.nombre || values.nombre.trim().length < 4) {
-    issues.push({ path: 'nombre', message: 'El nombre debe tener al menos 4 caracteres.' });
-  }
-
-  if (!['produccion', 'apoyo'].includes(values.tipo)) {
-    issues.push({ path: 'tipo', message: 'Selecciona un tipo válido.' });
-  }
-
-  if (!values.responsable) {
-    issues.push({ path: 'responsable', message: 'Debes asignar un responsable.' });
+  if (!nombre) {
+    issues.push({ path: 'nombre', message: 'El nombre es obligatorio.' });
+  } else if (nombre.length < 3) {
+    issues.push({ path: 'nombre', message: 'Ingresa al menos 3 caracteres.' });
   }
 
   if (issues.length) {
     return { success: false, issues } satisfies ValidationResult<CentroFormValues>;
   }
 
-  return { success: true, data: values };
+  return { success: true, data: { nombre, nroCentro } };
 };

--- a/frontend-app/src/modules/configuracion/schemas/empleadoSchema.ts
+++ b/frontend-app/src/modules/configuracion/schemas/empleadoSchema.ts
@@ -1,46 +1,28 @@
 import type { ValidationIssue, ValidationResult, Validator } from './types';
 
 export interface EmpleadoFormValues {
-  identificador: string;
   nombre: string;
-  correo: string;
-  activo: boolean;
-  centroAsignado: string;
 }
 
 export const defaultEmpleadoValues: EmpleadoFormValues = {
-  identificador: '',
   nombre: '',
-  correo: '',
-  activo: true,
-  centroAsignado: '',
 };
-
-const correoPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const empleadoValidator: Validator<EmpleadoFormValues> = (input) => {
   const values = { ...defaultEmpleadoValues, ...(input as Partial<EmpleadoFormValues>) };
   const issues: ValidationIssue[] = [];
 
-  if (!values.identificador.trim()) {
-    issues.push({ path: 'identificador', message: 'El identificador es obligatorio.' });
-  }
+  const nombre = values.nombre.trim();
 
-  if (!values.nombre || values.nombre.trim().length < 4) {
-    issues.push({ path: 'nombre', message: 'Incluye nombre y apellidos.' });
-  }
-
-  if (!values.correo || !correoPattern.test(values.correo)) {
-    issues.push({ path: 'correo', message: 'Correo electrónico inválido.' });
-  }
-
-  if (!values.centroAsignado) {
-    issues.push({ path: 'centroAsignado', message: 'Selecciona un centro asignado.' });
+  if (!nombre) {
+    issues.push({ path: 'nombre', message: 'El nombre del empleado es obligatorio.' });
+  } else if (nombre.length < 3) {
+    issues.push({ path: 'nombre', message: 'Ingresa al menos 3 caracteres.' });
   }
 
   if (issues.length) {
     return { success: false, issues } satisfies ValidationResult<EmpleadoFormValues>;
   }
 
-  return { success: true, data: values };
+  return { success: true, data: { nombre } };
 };


### PR DESCRIPTION
## Summary
- point the HTTP client to the local backend by default so catalog requests hit the running API
- simplify the catalog data hook and entity hooks to match the backend payloads for actividades, empleados y centros
- redesign the actividades, empleados and centros screens to present tables first, hide forms behind toggle buttons and refresh the navigation/toolbar styling

## Testing
- npm run build *(fails: missing `vite/client` and `node` type definitions because `npm install` could not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e494ffd43c8330b7b1e9c7e522b7d2