### PR TITLE
feat: redesign layout and paginate catalog tables

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -1,113 +1,119 @@
 .app-shell {
-  margin: 0 auto;
-  padding: 48px 24px 64px;
-  max-width: 1280px;
+  min-height: 100vh;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: #0f172a;
+  background: #f1f5f9;
   display: flex;
   flex-direction: column;
-  gap: 32px;
 }
 
-.app-header {
-  position: relative;
-  overflow: hidden;
-  border-radius: 28px;
-  padding: 32px;
+.app-navbar {
+  width: 100%;
   background: linear-gradient(135deg, #1d4ed8 0%, #22d3ee 100%);
   color: #f8fafc;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-navbar__content {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 18px 32px;
   display: flex;
-  flex-wrap: wrap;
-  gap: 28px;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+  gap: 24px;
 }
 
-.app-header::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), transparent 55%),
-    radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.15), transparent 50%);
-  pointer-events: none;
-}
-
-.app-header__brand {
+.app-navbar__brand {
   display: flex;
-  gap: 20px;
   align-items: center;
-  position: relative;
-  z-index: 1;
+  gap: 16px;
 }
 
-.app-header__logo {
-  width: 64px;
-  height: 64px;
-  border-radius: 20px;
+.app-navbar__logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
   display: grid;
   place-items: center;
-  font-size: 2rem;
-  background: rgba(248, 250, 252, 0.2);
+  font-size: 1.75rem;
+  background: rgba(248, 250, 252, 0.18);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
-.app-header__headline h1 {
-  margin: 8px 0 12px;
-  font-size: 2.25rem;
-  letter-spacing: -0.03em;
+.app-navbar__headline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.app-header__eyebrow {
+.app-navbar__eyebrow {
+  margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.16em;
   font-size: 0.75rem;
   font-weight: 600;
-  margin: 0;
   opacity: 0.85;
 }
 
-.app-header__subtitle {
+.app-navbar__title {
   margin: 0;
-  font-size: 1rem;
-  max-width: 480px;
+  font-size: 1.85rem;
+  letter-spacing: -0.02em;
+}
+
+.app-navbar__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  max-width: 420px;
   line-height: 1.5;
-  opacity: 0.85;
+  opacity: 0.9;
 }
 
-.app-header__actions {
+.app-navbar__actions {
   display: flex;
   gap: 12px;
-  position: relative;
-  z-index: 1;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
-.app-header__action {
+.app-navbar__action {
   border: 0;
   border-radius: 9999px;
-  padding: 12px 20px;
+  padding: 10px 18px;
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
   color: #0f172a;
-  background: rgba(248, 250, 252, 0.8);
+  background: rgba(248, 250, 252, 0.82);
   backdrop-filter: blur(6px);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
-.app-header__action:hover {
+.app-navbar__action:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
 }
 
-.app-header__action--primary {
+.app-navbar__action--primary {
   background: #f8fafc;
   color: #1d4ed8;
 }
 
+.app-shell__content {
+  flex: 1;
+  width: 100%;
+  padding: 32px 24px 48px;
+}
+
 .app-layout {
+  max-width: 1280px;
+  margin: 0 auto;
   display: grid;
-  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
   align-items: start;
   gap: 32px;
 }
@@ -222,24 +228,30 @@
     position: static;
     order: 2;
   }
-
-  .app-header {
-    padding: 28px 24px;
-  }
 }
 
 @media (max-width: 640px) {
-  .app-shell {
-    padding: 32px 16px 48px;
+  .app-shell__content {
+    padding: 24px 16px 40px;
   }
 
-  .app-header__actions {
+  .app-navbar__content {
+    padding: 18px 20px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-navbar__actions {
     width: 100%;
-    justify-content: center;
+    justify-content: flex-start;
   }
 
-  .app-header__action {
-    flex: 1;
+  .app-navbar__action {
+    flex: 1 1 auto;
     text-align: center;
+  }
+
+  .app-navbar__subtitle {
+    max-width: none;
   }
 }

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -4,29 +4,32 @@ import './App.css';
 function App() {
   return (
     <div className="app-shell">
-      <header className="app-header">
-        <div className="app-header__brand">
-          <div className="app-header__logo" aria-hidden="true">
-            🌿
+      <header className="app-navbar">
+        <div className="app-navbar__content">
+          <div className="app-navbar__brand">
+            <div className="app-navbar__logo" aria-hidden="true">
+              🌿
+            </div>
+            <div className="app-navbar__headline">
+              <p className="app-navbar__eyebrow">Suite Herbal ERP</p>
+              <h1 className="app-navbar__title">Configuración y catálogos</h1>
+              <p className="app-navbar__subtitle">
+                Administra los catálogos maestros y parámetros generales utilizados por los módulos operativos.
+              </p>
+            </div>
           </div>
-          <div className="app-header__headline">
-            <p className="app-header__eyebrow">Suite Herbal ERP</p>
-            <h1>Configuración y catálogos</h1>
-            <p className="app-header__subtitle">
-              Administra los catálogos maestros y parámetros generales utilizados por los módulos operativos.
-            </p>
+          <div className="app-navbar__actions" aria-label="Acciones rápidas">
+            <button type="button" className="app-navbar__action app-navbar__action--primary">
+              Agregar catálogo
+            </button>
+            <button type="button" className="app-navbar__action">Centro de ayuda</button>
           </div>
-        </div>
-        <div className="app-header__actions" aria-label="Acciones rápidas">
-          <button type="button" className="app-header__action app-header__action--primary">
-            Agregar catálogo
-          </button>
-          <button type="button" className="app-header__action">Centro de ayuda</button>
         </div>
       </header>
 
-      <div className="app-layout">
-        <aside className="app-sidebar" aria-label="Panel contextual de configuración">
+      <div className="app-shell__content">
+        <div className="app-layout">
+          <aside className="app-sidebar" aria-label="Panel contextual de configuración">
           <section className="app-sidebar__section">
             <h2 className="app-sidebar__title">Resumen del panel</h2>
             <p className="app-sidebar__description">
@@ -69,11 +72,12 @@ function App() {
               </li>
             </ul>
           </section>
-        </aside>
+          </aside>
 
-        <main className="app-main">
-          <ConfiguracionModule />
-        </main>
+          <main className="app-main">
+            <ConfiguracionModule />
+          </main>
+        </div>
       </div>
     </div>
   );

--- a/frontend-app/src/modules/configuracion/components/CatalogTable.tsx
+++ b/frontend-app/src/modules/configuracion/components/CatalogTable.tsx
@@ -13,9 +13,41 @@ interface CatalogTableProps<TEntity> {
   columns: CatalogTableColumn<TEntity>[];
   loading?: boolean;
   emptyMessage?: string;
+  pageSize?: number;
 }
 
-const CatalogTable = <TEntity,>({ rows, columns, loading, emptyMessage }: CatalogTableProps<TEntity>) => {
+const CatalogTable = <TEntity,>({
+  rows,
+  columns,
+  loading,
+  emptyMessage,
+  pageSize = 10,
+}: CatalogTableProps<TEntity>) => {
+  const [page, setPage] = React.useState(1);
+
+  React.useEffect(() => {
+    setPage(1);
+  }, [rows, pageSize]);
+
+  const totalPages = React.useMemo(
+    () => Math.max(1, Math.ceil(rows.length / pageSize)),
+    [rows.length, pageSize],
+  );
+
+  React.useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
+
+  const pageRows = React.useMemo(() => {
+    const startIndex = (page - 1) * pageSize;
+    return rows.slice(startIndex, startIndex + pageSize);
+  }, [page, pageSize, rows]);
+
+  const from = rows.length === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, rows.length);
+
   if (loading) {
     return <div className="table-empty">Cargando catálogo…</div>;
   }
@@ -25,27 +57,58 @@ const CatalogTable = <TEntity,>({ rows, columns, loading, emptyMessage }: Catalo
   }
 
   return (
-    <div style={{ overflowX: 'auto' }}>
-      <table className="config-table">
-        <thead>
-          <tr>
-            {columns.map((column) => (
-              <th key={String(column.key)} style={{ width: column.width }}>{column.label}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, index) => (
-            <tr key={String((row as any).id ?? index)}>
+    <div className="config-table__container">
+      <div className="config-table__scroll" style={{ overflowX: 'auto' }}>
+        <table className="config-table">
+          <thead>
+            <tr>
               {columns.map((column) => (
-                <td key={String(column.key)}>
-                  {column.render ? column.render(row) : (row as Record<string, unknown>)[column.key as string]}
-                </td>
+                <th key={String(column.key)} style={{ width: column.width }}>
+                  {column.label}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {pageRows.map((row, index) => (
+              <tr key={String((row as any).id ?? `${page}-${index}`)}>
+                {columns.map((column) => (
+                  <td key={String(column.key)}>
+                    {column.render ? column.render(row) : (row as Record<string, unknown>)[column.key as string]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="config-table__pagination" aria-label="Paginación de tabla">
+        <span className="config-table__pagination-info">
+          Mostrando {from.toLocaleString()}-{to.toLocaleString()} de {rows.length.toLocaleString()}
+        </span>
+        <div className="config-table__pagination-actions">
+          <button
+            type="button"
+            className="config-pagination-button"
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+            disabled={page === 1}
+          >
+            Anterior
+          </button>
+          <span className="config-table__pagination-page">
+            Página {page} de {totalPages}
+          </span>
+          <button
+            type="button"
+            className="config-pagination-button"
+            onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+            disabled={page === totalPages}
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -334,6 +334,65 @@ textarea.config-input {
   box-shadow: 0 28px 48px rgba(15, 23, 42, 0.12);
 }
 
+.config-table__container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.config-table__pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 12px 16px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.config-table__pagination-info {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.config-table__pagination-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.config-pagination-button {
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  background: #f8fafc;
+  color: #1d4ed8;
+  border-radius: 9999px;
+  padding: 8px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.config-pagination-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+.config-pagination-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.config-table__pagination-page {
+  font-size: 0.85rem;
+  color: #475569;
+  font-weight: 600;
+}
+
 .config-table thead th {
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(30, 64, 175, 0.08));
   color: #1f2937;

--- a/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
@@ -53,6 +53,7 @@ const ActividadesPage: React.FC = () => {
       showToast('Actividad creada correctamente.', 'success');
       form.reset();
       setIsFormOpen(false);
+      await catalog.refetch();
     } catch (error) {
       showToast('No se pudo crear la actividad. Intenta nuevamente.', 'error');
     }
@@ -86,30 +87,34 @@ const ActividadesPage: React.FC = () => {
           </div>
         </header>
 
-        <CatalogFilterBar
-          value={filters}
-          onChange={handleFiltersChange}
-          disabled={catalog.isLoading}
-          hideStatus
-          hideUpdatedBy
-          searchPlaceholder="Buscar por nombre o número"
-        />
+        {!isFormOpen && (
+          <>
+            <CatalogFilterBar
+              value={filters}
+              onChange={handleFiltersChange}
+              disabled={catalog.isLoading}
+              hideStatus
+              hideUpdatedBy
+              searchPlaceholder="Buscar por nombre o número"
+            />
 
-        {catalog.error && (
-          <div className="config-alert" role="alert">
-            <span>No pudimos cargar las actividades. Intenta nuevamente.</span>
-            <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
-              Reintentar
-            </button>
-          </div>
+            {catalog.error && (
+              <div className="config-alert" role="alert">
+                <span>No pudimos cargar las actividades. Intenta nuevamente.</span>
+                <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+                  Reintentar
+                </button>
+              </div>
+            )}
+
+            <CatalogTable
+              rows={actividades}
+              columns={columns}
+              loading={catalog.isLoading}
+              emptyMessage="No hay actividades registradas."
+            />
+          </>
         )}
-
-        <CatalogTable
-          rows={actividades}
-          columns={columns}
-          loading={catalog.isLoading}
-          emptyMessage="No hay actividades registradas."
-        />
       </section>
 
       {isFormOpen && (

--- a/frontend-app/src/modules/configuracion/pages/CentrosPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosPage.tsx
@@ -56,6 +56,7 @@ const CentrosPage: React.FC = () => {
       showToast('Centro creado correctamente.', 'success');
       form.reset();
       setIsFormOpen(false);
+      await catalog.refetch();
     } catch (error) {
       showToast('No se pudo crear el centro.', 'error');
     }
@@ -89,30 +90,34 @@ const CentrosPage: React.FC = () => {
           </div>
         </header>
 
-        <CatalogFilterBar
-          value={filters}
-          onChange={handleFiltersChange}
-          disabled={catalog.isLoading}
-          hideStatus
-          hideUpdatedBy
-          searchPlaceholder="Buscar por número o nombre"
-        />
+        {!isFormOpen && (
+          <>
+            <CatalogFilterBar
+              value={filters}
+              onChange={handleFiltersChange}
+              disabled={catalog.isLoading}
+              hideStatus
+              hideUpdatedBy
+              searchPlaceholder="Buscar por número o nombre"
+            />
 
-        {catalog.error && (
-          <div className="config-alert" role="alert">
-            <span>No pudimos cargar los centros. Intenta nuevamente.</span>
-            <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
-              Reintentar
-            </button>
-          </div>
+            {catalog.error && (
+              <div className="config-alert" role="alert">
+                <span>No pudimos cargar los centros. Intenta nuevamente.</span>
+                <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+                  Reintentar
+                </button>
+              </div>
+            )}
+
+            <CatalogTable
+              rows={centros}
+              columns={columns}
+              loading={catalog.isLoading}
+              emptyMessage="No hay centros registrados."
+            />
+          </>
         )}
-
-        <CatalogTable
-          rows={centros}
-          columns={columns}
-          loading={catalog.isLoading}
-          emptyMessage="No hay centros registrados."
-        />
       </section>
 
       {isFormOpen && (

--- a/frontend-app/src/modules/configuracion/pages/EmpleadosPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/EmpleadosPage.tsx
@@ -53,6 +53,7 @@ const EmpleadosPage: React.FC = () => {
       showToast('Empleado registrado correctamente.', 'success');
       form.reset();
       setIsFormOpen(false);
+      await catalog.refetch();
     } catch (error) {
       showToast('No se pudo registrar el empleado.', 'error');
     }
@@ -86,30 +87,34 @@ const EmpleadosPage: React.FC = () => {
           </div>
         </header>
 
-        <CatalogFilterBar
-          value={filters}
-          onChange={handleFiltersChange}
-          disabled={catalog.isLoading}
-          hideStatus
-          hideUpdatedBy
-          searchPlaceholder="Buscar por número o nombre"
-        />
+        {!isFormOpen && (
+          <>
+            <CatalogFilterBar
+              value={filters}
+              onChange={handleFiltersChange}
+              disabled={catalog.isLoading}
+              hideStatus
+              hideUpdatedBy
+              searchPlaceholder="Buscar por número o nombre"
+            />
 
-        {catalog.error && (
-          <div className="config-alert" role="alert">
-            <span>No pudimos cargar los empleados. Intenta nuevamente.</span>
-            <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
-              Reintentar
-            </button>
-          </div>
+            {catalog.error && (
+              <div className="config-alert" role="alert">
+                <span>No pudimos cargar los empleados. Intenta nuevamente.</span>
+                <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+                  Reintentar
+                </button>
+              </div>
+            )}
+
+            <CatalogTable
+              rows={empleados}
+              columns={columns}
+              loading={catalog.isLoading}
+              emptyMessage="No hay empleados registrados."
+            />
+          </>
         )}
-
-        <CatalogTable
-          rows={empleados}
-          columns={columns}
-          loading={catalog.isLoading}
-          emptyMessage="No hay empleados registrados."
-        />
       </section>
 
       {isFormOpen && (


### PR DESCRIPTION
## Summary
- rework the application shell with a full-width sticky top navigation bar
- add reusable pagination controls to catalog tables and supporting styles
- hide catalog listings while forms are open and refetch data after creating new records

## Testing
- ⚠️ `npm run build` *(fails: missing `vite/client` and `node` type definitions because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e49c4c87f08330a9352a2840084925