### PR TITLE
Refresh configuration UI and catalog interactions

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -1,26 +1,52 @@
+:root {
+  --font-family-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-surface: #f5f6f8;
+  --color-surface-alt: #ffffff;
+  --color-outline: #d0d7e2;
+  --color-outline-strong: #a7b4c7;
+  --color-text-primary: #1e293b;
+  --color-text-secondary: #475569;
+  --color-primary: #145ea8;
+  --color-primary-variant: #0b4a84;
+  --color-primary-container: #e3efff;
+  --color-on-primary: #ffffff;
+  --color-on-primary-container: #0b2c4a;
+  --shadow-level-1: 0 10px 30px rgba(15, 23, 42, 0.1);
+  --shadow-level-2: 0 16px 40px rgba(15, 23, 42, 0.14);
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
 .app-shell {
   min-height: 100vh;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #0f172a;
-  background: #f1f5f9;
   display: flex;
   flex-direction: column;
+  background: var(--color-surface);
 }
 
 .app-navbar {
   width: 100%;
-  background: linear-gradient(135deg, #1d4ed8 0%, #22d3ee 100%);
-  color: #f8fafc;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.25);
+  background: var(--color-surface-alt);
+  border-bottom: 1px solid var(--color-outline);
   position: sticky;
   top: 0;
   z-index: 10;
 }
 
 .app-navbar__content {
-  max-width: 1280px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 18px 32px;
+  padding: 16px 24px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -34,14 +60,15 @@
 }
 
 .app-navbar__logo {
-  width: 56px;
-  height: 56px;
-  border-radius: 18px;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
   display: grid;
   place-items: center;
-  font-size: 1.75rem;
-  background: rgba(248, 250, 252, 0.18);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  font-size: 1.5rem;
+  background: var(--color-primary-container);
+  color: var(--color-on-primary-container);
+  border: 1px solid var(--color-outline);
 }
 
 .app-navbar__headline {
@@ -53,24 +80,23 @@
 .app-navbar__eyebrow {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
   font-weight: 600;
-  opacity: 0.85;
+  color: var(--color-primary-variant);
 }
 
 .app-navbar__title {
   margin: 0;
-  font-size: 1.85rem;
-  letter-spacing: -0.02em;
+  font-size: 1.6rem;
+  font-weight: 650;
 }
 
 .app-navbar__subtitle {
   margin: 0;
   font-size: 0.95rem;
-  max-width: 420px;
-  line-height: 1.5;
-  opacity: 0.9;
+  color: var(--color-text-secondary);
+  max-width: 460px;
 }
 
 .app-navbar__actions {
@@ -81,80 +107,109 @@
 }
 
 .app-navbar__action {
-  border: 0;
-  border-radius: 9999px;
-  padding: 10px 18px;
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  padding: 10px 16px;
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
-  color: #0f172a;
-  background: rgba(248, 250, 252, 0.82);
-  backdrop-filter: blur(6px);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  color: var(--color-primary-variant);
+  background: transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .app-navbar__action:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+  background: rgba(20, 94, 168, 0.08);
+  border-color: var(--color-primary-variant);
 }
 
 .app-navbar__action--primary {
-  background: #f8fafc;
-  color: #1d4ed8;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
 }
 
 .app-shell__content {
   flex: 1;
   width: 100%;
-  padding: 32px 24px 48px;
+  padding: 24px 16px 48px;
 }
 
 .app-layout {
-  max-width: 1280px;
+  max-width: 1200px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
   align-items: start;
-  gap: 32px;
+}
+
+.app-sidebar__toggle {
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-alt);
+  color: var(--color-text-primary);
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 .app-sidebar {
-  position: sticky;
-  top: 32px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-alt);
+  border-radius: 16px;
+  padding: 20px 18px;
+  box-shadow: var(--shadow-level-1);
+  display: none;
+}
+
+.app-sidebar[data-open='true'] {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  background: #ffffff;
-  border-radius: 24px;
-  padding: 28px 24px;
-  border: 1px solid rgba(15, 23, 42, 0.06);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  gap: 12px;
 }
 
 .app-sidebar__section {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.app-sidebar__section.is-open {
+  border-color: var(--color-outline);
+  background: rgba(20, 94, 168, 0.05);
+}
+
+.app-sidebar__section-toggle {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 12px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.app-sidebar__section-body {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.app-sidebar__title {
-  margin: 0;
-  font-size: 1.125rem;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.app-sidebar__subtitle {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #1d4ed8;
+  gap: 12px;
+  padding: 0 8px 12px;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
 }
 
 .app-sidebar__description {
   margin: 0;
-  font-size: 0.95rem;
-  color: #475569;
+  line-height: 1.4;
 }
 
 .app-sidebar__stats {
@@ -162,28 +217,24 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .app-sidebar__stat {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  background: linear-gradient(135deg, rgba(30, 64, 175, 0.08), rgba(56, 189, 248, 0.08));
-  border-radius: 18px;
-  padding: 16px;
-  border: 1px solid rgba(30, 64, 175, 0.12);
+  gap: 2px;
 }
 
 .app-sidebar__stat-value {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #1d4ed8;
+  font-size: 1.1rem;
+  font-weight: 650;
+  color: var(--color-primary-variant);
 }
 
 .app-sidebar__stat-label {
+  color: var(--color-text-secondary);
   font-size: 0.85rem;
-  color: #475569;
 }
 
 .app-sidebar__links {
@@ -192,25 +243,23 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
 }
 
 .app-sidebar__link {
   width: 100%;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: #f8fafc;
-  border-radius: 12px;
-  padding: 12px 16px;
   text-align: left;
+  border: none;
+  background: none;
+  color: var(--color-primary-variant);
   font-weight: 600;
-  color: #1f2937;
+  padding: 8px 4px;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 8px;
 }
 
 .app-sidebar__link:hover {
-  transform: translateX(4px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
+  background: rgba(20, 94, 168, 0.12);
 }
 
 .app-main {
@@ -219,24 +268,26 @@
   gap: 24px;
 }
 
-@media (max-width: 1024px) {
+@media (min-width: 1024px) {
+  .app-shell__content {
+    padding: 32px 24px 56px;
+  }
+
   .app-layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+  }
+
+  .app-sidebar__toggle {
+    display: none;
   }
 
   .app-sidebar {
-    position: static;
-    order: 2;
+    display: flex;
   }
 }
 
 @media (max-width: 640px) {
-  .app-shell__content {
-    padding: 24px 16px 40px;
-  }
-
   .app-navbar__content {
-    padding: 18px 20px;
     flex-direction: column;
     align-items: flex-start;
   }
@@ -249,9 +300,5 @@
   .app-navbar__action {
     flex: 1 1 auto;
     text-align: center;
-  }
-
-  .app-navbar__subtitle {
-    max-width: none;
   }
 }

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -1,7 +1,25 @@
+import { useEffect, useState } from 'react';
 import ConfiguracionModule from './modules/configuracion';
 import './App.css';
 
 function App() {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(true);
+  const [openSections, setOpenSections] = useState({ overview: true, shortcuts: false });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsDrawerOpen(window.innerWidth >= 1024);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const toggleSection = (section: keyof typeof openSections) => {
+    setOpenSections((current) => ({ ...current, [section]: !current[section] }));
+  };
+
   return (
     <div className="app-shell">
       <header className="app-navbar">
@@ -29,49 +47,84 @@ function App() {
 
       <div className="app-shell__content">
         <div className="app-layout">
-          <aside className="app-sidebar" aria-label="Panel contextual de configuración">
-          <section className="app-sidebar__section">
-            <h2 className="app-sidebar__title">Resumen del panel</h2>
-            <p className="app-sidebar__description">
-              Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de publicar
-              cambios.
-            </p>
-            <ul className="app-sidebar__stats">
-              <li className="app-sidebar__stat">
-                <span className="app-sidebar__stat-value">4</span>
-                <span className="app-sidebar__stat-label">Catálogos activos</span>
-              </li>
-              <li className="app-sidebar__stat">
-                <span className="app-sidebar__stat-value">3</span>
-                <span className="app-sidebar__stat-label">Dependencias críticas</span>
-              </li>
-              <li className="app-sidebar__stat">
-                <span className="app-sidebar__stat-value">En línea</span>
-                <span className="app-sidebar__stat-label">Estado de sincronización</span>
-              </li>
-            </ul>
-          </section>
+          <button
+            type="button"
+            className="app-sidebar__toggle"
+            onClick={() => setIsDrawerOpen((open) => !open)}
+            aria-expanded={isDrawerOpen}
+            aria-controls="app-sidebar"
+          >
+            {isDrawerOpen ? 'Ocultar panel' : 'Mostrar panel'}
+          </button>
 
-          <section className="app-sidebar__section">
-            <h3 className="app-sidebar__subtitle">Atajos recomendados</h3>
-            <ul className="app-sidebar__links">
-              <li>
-                <button type="button" className="app-sidebar__link">
-                  Revisar dependencias
-                </button>
-              </li>
-              <li>
-                <button type="button" className="app-sidebar__link">
-                  Programar sincronización
-                </button>
-              </li>
-              <li>
-                <button type="button" className="app-sidebar__link">
-                  Descargar respaldo
-                </button>
-              </li>
-            </ul>
-          </section>
+          <aside
+            id="app-sidebar"
+            className="app-sidebar"
+            aria-label="Panel contextual de configuración"
+            data-open={isDrawerOpen}
+          >
+            <section className={`app-sidebar__section ${openSections.overview ? 'is-open' : ''}`}>
+              <button
+                type="button"
+                className="app-sidebar__section-toggle"
+                onClick={() => toggleSection('overview')}
+                aria-expanded={openSections.overview}
+              >
+                <span>Resumen del panel</span>
+                <span aria-hidden="true">{openSections.overview ? '−' : '+'}</span>
+              </button>
+              <div className="app-sidebar__section-body" hidden={!openSections.overview}>
+                <p className="app-sidebar__description">
+                  Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de publicar
+                  cambios.
+                </p>
+                <ul className="app-sidebar__stats">
+                  <li className="app-sidebar__stat">
+                    <span className="app-sidebar__stat-value">4</span>
+                    <span className="app-sidebar__stat-label">Catálogos activos</span>
+                  </li>
+                  <li className="app-sidebar__stat">
+                    <span className="app-sidebar__stat-value">3</span>
+                    <span className="app-sidebar__stat-label">Dependencias críticas</span>
+                  </li>
+                  <li className="app-sidebar__stat">
+                    <span className="app-sidebar__stat-value">En línea</span>
+                    <span className="app-sidebar__stat-label">Estado de sincronización</span>
+                  </li>
+                </ul>
+              </div>
+            </section>
+
+            <section className={`app-sidebar__section ${openSections.shortcuts ? 'is-open' : ''}`}>
+              <button
+                type="button"
+                className="app-sidebar__section-toggle"
+                onClick={() => toggleSection('shortcuts')}
+                aria-expanded={openSections.shortcuts}
+              >
+                <span>Atajos recomendados</span>
+                <span aria-hidden="true">{openSections.shortcuts ? '−' : '+'}</span>
+              </button>
+              <div className="app-sidebar__section-body" hidden={!openSections.shortcuts}>
+                <ul className="app-sidebar__links">
+                  <li>
+                    <button type="button" className="app-sidebar__link">
+                      Revisar dependencias
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" className="app-sidebar__link">
+                      Programar sincronización
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" className="app-sidebar__link">
+                      Descargar respaldo
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </section>
           </aside>
 
           <main className="app-main">

--- a/frontend-app/src/modules/configuracion/components/CatalogTable.tsx
+++ b/frontend-app/src/modules/configuracion/components/CatalogTable.tsx
@@ -14,6 +14,7 @@ interface CatalogTableProps<TEntity> {
   loading?: boolean;
   emptyMessage?: string;
   pageSize?: number;
+  pageSizeOptions?: number[];
 }
 
 const CatalogTable = <TEntity,>({
@@ -21,9 +22,15 @@ const CatalogTable = <TEntity,>({
   columns,
   loading,
   emptyMessage,
-  pageSize = 10,
+  pageSize: initialPageSize = 10,
+  pageSizeOptions = [10, 25, 50],
 }: CatalogTableProps<TEntity>) => {
   const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(initialPageSize);
+
+  React.useEffect(() => {
+    setPageSize(initialPageSize);
+  }, [initialPageSize]);
 
   React.useEffect(() => {
     setPage(1);
@@ -47,6 +54,11 @@ const CatalogTable = <TEntity,>({
 
   const from = rows.length === 0 ? 0 : (page - 1) * pageSize + 1;
   const to = Math.min(page * pageSize, rows.length);
+
+  const normalizedPageSizeOptions = React.useMemo(() => {
+    const uniqueOptions = new Set([...pageSizeOptions, pageSize]);
+    return Array.from(uniqueOptions).sort((a, b) => a - b);
+  }, [pageSizeOptions, pageSize]);
 
   if (loading) {
     return <div className="table-empty">Cargando catálogo…</div>;
@@ -88,6 +100,17 @@ const CatalogTable = <TEntity,>({
           Mostrando {from.toLocaleString()}-{to.toLocaleString()} de {rows.length.toLocaleString()}
         </span>
         <div className="config-table__pagination-actions">
+          <label className="config-table__page-size">
+            Mostrar
+            <select value={pageSize} onChange={(event) => setPageSize(Number(event.target.value))}>
+              {normalizedPageSizeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+            registros
+          </label>
           <button
             type="button"
             className="config-pagination-button"

--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -1,21 +1,21 @@
 .configuracion-module {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 .config-breadcrumbs {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
-  background: linear-gradient(135deg, rgba(30, 64, 175, 0.16), rgba(14, 165, 233, 0.08));
-  border: 1px solid rgba(30, 64, 175, 0.2);
-  border-radius: 18px;
-  padding: 12px 16px;
-  font-size: 0.85rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  padding: 8px 12px;
+  font-size: 0.82rem;
   font-weight: 600;
-  color: #1e3a8a;
+  color: var(--color-text-secondary);
 }
 
 .config-breadcrumbs__item {
@@ -25,15 +25,15 @@
 }
 
 .config-breadcrumbs__separator {
-  color: rgba(30, 64, 175, 0.5);
+  color: var(--color-outline-strong);
 }
 
 .config-nav {
-  background: #ffffff;
-  border-radius: 20px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
-  padding: 4px 16px;
+  background: var(--color-surface-alt);
+  border-radius: 14px;
+  border: 1px solid var(--color-outline);
+  padding: 6px 12px;
+  overflow-x: auto;
 }
 
 .config-nav__list {
@@ -43,81 +43,73 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  overflow-x: auto;
-}
-
-.config-nav__list > li {
-  display: flex;
 }
 
 .config-nav__item {
   border: none;
-  border-bottom: 3px solid transparent;
-  border-radius: 12px 12px 0 0;
   background: transparent;
-  padding: 14px 20px;
+  border-radius: 10px;
+  padding: 10px 16px;
   font-weight: 600;
-  color: #475569;
+  color: var(--color-text-secondary);
   cursor: pointer;
   white-space: nowrap;
-  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .config-nav__item:hover {
-  color: #1d4ed8;
-  background: rgba(37, 99, 235, 0.08);
+  background: rgba(20, 94, 168, 0.08);
+  color: var(--color-primary-variant);
 }
 
 .config-nav__item:focus-visible {
-  outline: 2px solid #2563eb;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
 .config-nav__item--active {
-  color: #1e3a8a;
-  border-bottom-color: #2563eb;
-  background: rgba(37, 99, 235, 0.14);
+  color: var(--color-primary-variant);
+  background: rgba(20, 94, 168, 0.12);
 }
 
 .config-section {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: 28px;
-  border-radius: 24px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: radial-gradient(circle at 0% 0%, rgba(30, 64, 175, 0.06), transparent 55%), #ffffff;
-  box-shadow: 0 26px 40px rgba(15, 23, 42, 0.1);
+  gap: 18px;
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-alt);
+  box-shadow: var(--shadow-level-1);
 }
 
 .config-section__title {
-  font-size: 1.35rem;
-  font-weight: 700;
+  font-size: 1.25rem;
+  font-weight: 650;
   margin: 0;
-  color: #0f172a;
+  color: var(--color-text-primary);
 }
 
 .config-section header p {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
 }
 
 .config-form {
   display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .config-form-field {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(15, 23, 42, 0.05);
-  background: linear-gradient(145deg, rgba(248, 250, 252, 0.95), rgba(255, 255, 255, 0.95));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  gap: 8px;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.65);
 }
 
 .config-form-field--full {
@@ -133,33 +125,37 @@
 }
 
 .config-field-label {
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-weight: 700;
-  color: #1f2937;
+  font-weight: 650;
+  color: var(--color-text-secondary);
 }
 
 .config-field-error {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: #b91c1c;
-  background: rgba(248, 113, 113, 0.16);
-  border-radius: 10px;
-  padding: 6px 10px;
 }
 
 .config-input,
 .config-select {
   width: 100%;
-  padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.1);
-  background: #ffffff;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-alt);
   font-size: 0.95rem;
+  color: var(--color-text-primary);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.config-input:focus,
+.config-select:focus {
+  outline: none;
+  border-color: var(--color-primary-variant);
+  box-shadow: 0 0 0 3px rgba(20, 94, 168, 0.14);
 }
 
 textarea.config-input {
@@ -167,16 +163,9 @@ textarea.config-input {
   resize: vertical;
 }
 
-.config-input:focus,
-.config-select:focus {
-  outline: none;
-  border-color: rgba(37, 99, 235, 0.8);
-  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.16), 0 16px 28px rgba(37, 99, 235, 0.18);
-}
-
 .config-select {
   appearance: none;
-  background-image: url("data:image/svg+xml,<svg fill='none' height='16' viewBox='0 0 24 24' width='16' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5' stroke='%231d4ed8' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'/></svg>");
+  background-image: url("data:image/svg+xml,<svg fill='none' height='16' viewBox='0 0 24 24' width='16' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5' stroke='%23145ea8' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'/></svg>");
   background-position: right 12px center;
   background-repeat: no-repeat;
   background-size: 16px;
@@ -186,85 +175,59 @@ textarea.config-input {
 .config-checkbox {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-text-secondary);
 }
 
 .config-checkbox input {
   width: 18px;
   height: 18px;
-  border-radius: 6px;
-  border: 1px solid rgba(15, 23, 42, 0.2);
-  accent-color: #1d4ed8;
-}
-
-.config-form-actions {
-  grid-column: 1 / -1;
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-  padding-top: 12px;
+  border-radius: 4px;
+  border: 1px solid var(--color-outline);
+  accent-color: var(--color-primary);
 }
 
 .config-button {
-  padding: 10px 20px;
-  border-radius: 9999px;
+  border-radius: 12px;
   border: 1px solid transparent;
+  padding: 10px 18px;
   font-weight: 600;
+  font-size: 0.95rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .config-button--primary {
-  background: linear-gradient(135deg, #2563eb, #22d3ee);
-  color: #fff;
-  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.35);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
 }
 
-.config-button--primary:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 20px 36px rgba(37, 99, 235, 0.4);
-}
-
-.config-button--primary:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  box-shadow: none;
+.config-button--primary:hover {
+  background: var(--color-primary-variant);
 }
 
 .config-button--ghost {
-  background: #ffffff;
-  border-color: rgba(15, 23, 42, 0.15);
-  color: #1f2937;
+  background: transparent;
+  border-color: var(--color-outline);
+  color: var(--color-primary-variant);
 }
 
 .config-button--ghost:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  background: rgba(20, 94, 168, 0.08);
 }
 
-.config-filter-bar {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  padding: 24px;
-  border-radius: 24px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: linear-gradient(140deg, rgba(248, 250, 252, 0.9), rgba(224, 242, 254, 0.9));
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
-}
-
-.config-filter-bar__field {
+.config-form-actions {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  justify-content: flex-end;
 }
 
 .catalog-view {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 .catalog-view__panel {
@@ -279,11 +242,11 @@ textarea.config-input {
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  background: #ffffff;
-  border-radius: 24px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
-  padding: 20px 24px;
+  background: var(--color-surface-alt);
+  border-radius: 16px;
+  border: 1px solid var(--color-outline);
+  padding: 18px 20px;
+  box-shadow: var(--shadow-level-1);
 }
 
 .catalog-view__header-text {
@@ -294,13 +257,13 @@ textarea.config-input {
 
 .catalog-view__title {
   margin: 0;
-  font-size: 1.25rem;
-  color: #0f172a;
+  font-size: 1.2rem;
+  color: var(--color-text-primary);
 }
 
 .catalog-view__subtitle {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
 }
 
@@ -317,21 +280,33 @@ textarea.config-input {
   gap: 6px;
   font-size: 0.85rem;
   font-weight: 600;
-  color: #1d4ed8;
-  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary-variant);
+  background: rgba(20, 94, 168, 0.1);
   padding: 6px 12px;
   border-radius: 9999px;
 }
 
-.config-table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  font-size: 0.95rem;
-  background: #ffffff;
-  border-radius: 24px;
-  overflow: hidden;
-  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.12);
+.catalog-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-outline);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: var(--shadow-level-1);
+}
+
+.config-filter-bar {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.config-filter-bar__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .config-table__container {
@@ -340,23 +315,56 @@ textarea.config-input {
   gap: 16px;
 }
 
+.config-table__scroll {
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  overflow: auto;
+}
+
+.config-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+  min-width: 560px;
+}
+
+.config-table thead th {
+  background: rgba(20, 94, 168, 0.08);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-outline);
+}
+
+.config-table tbody tr {
+  transition: background-color 0.2s ease;
+}
+
+.config-table tbody tr:hover {
+  background: rgba(20, 94, 168, 0.06);
+}
+
+.config-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-outline);
+  color: var(--color-text-primary);
+}
+
 .config-table__pagination {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: #ffffff;
-  border-radius: 18px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  padding: 12px 16px;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
 }
 
 .config-table__pagination-info {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-text-secondary);
 }
 
 .config-table__pagination-actions {
@@ -366,69 +374,70 @@ textarea.config-input {
 }
 
 .config-pagination-button {
-  border: 1px solid rgba(37, 99, 235, 0.4);
-  background: #f8fafc;
-  color: #1d4ed8;
-  border-radius: 9999px;
-  padding: 8px 16px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-alt);
+  color: var(--color-text-primary);
+  border-radius: 10px;
+  padding: 8px 14px;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .config-pagination-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+  background: rgba(20, 94, 168, 0.08);
 }
 
 .config-pagination-button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
-  box-shadow: none;
 }
 
 .config-table__pagination-page {
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--color-text-secondary);
   font-weight: 600;
 }
 
-.config-table thead th {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(30, 64, 175, 0.08));
-  color: #1f2937;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 0.75rem;
-  font-weight: 700;
-  padding: 16px 18px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+.config-table__page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
 }
 
-.config-table tbody tr {
-  transition: background-color 0.2s ease;
+.config-table__page-size select {
+  border: 1px solid var(--color-outline);
+  border-radius: 8px;
+  padding: 6px 10px;
+  background: var(--color-surface-alt);
+  font-size: 0.85rem;
 }
 
-.config-table tbody tr:nth-child(odd) {
-  background: rgba(248, 250, 252, 0.65);
+.catalog-row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
-.config-table tbody tr:nth-child(even) {
-  background: #ffffff;
+.catalog-row-actions button {
+  border: none;
+  background: none;
+  color: var(--color-primary-variant);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 6px;
 }
 
-.config-table td {
-  padding: 16px 18px;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.05);
-}
-
-.config-table tbody tr:hover {
-  background: rgba(191, 219, 254, 0.35);
+.catalog-row-actions button:hover {
+  background: rgba(20, 94, 168, 0.1);
 }
 
 .badge {
-  padding: 6px 10px;
+  padding: 4px 8px;
   border-radius: 9999px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 700;
   display: inline-flex;
   align-items: center;
@@ -438,26 +447,26 @@ textarea.config-input {
 }
 
 .badge--activo {
-  background: rgba(16, 185, 129, 0.16);
-  color: #047857;
+  background: rgba(22, 163, 74, 0.16);
+  color: #166534;
 }
 
 .badge--inactivo {
-  background: rgba(248, 113, 113, 0.16);
-  color: #b91c1c;
+  background: rgba(220, 38, 38, 0.16);
+  color: #991b1b;
 }
 
 .badge--sincronizando {
-  background: rgba(59, 130, 246, 0.16);
+  background: rgba(37, 99, 235, 0.16);
   color: #1d4ed8;
 }
 
 .sync-banner {
   padding: 16px 20px;
-  border-radius: 20px;
-  border: 1px solid rgba(59, 130, 246, 0.45);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(125, 211, 252, 0.12));
-  color: #1d4ed8;
+  border-radius: 14px;
+  border: 1px solid rgba(20, 94, 168, 0.3);
+  background: rgba(227, 239, 255, 0.8);
+  color: var(--color-primary-variant);
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -465,16 +474,16 @@ textarea.config-input {
 
 .audit-meta {
   font-size: 0.8rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .table-empty {
-  padding: 36px;
+  padding: 32px;
   text-align: center;
-  color: #475569;
-  border-radius: 20px;
-  border: 1px dashed rgba(148, 163, 184, 0.6);
-  background: rgba(226, 232, 240, 0.5);
+  color: var(--color-text-secondary);
+  border-radius: 12px;
+  border: 1px dashed var(--color-outline);
+  background: rgba(226, 232, 240, 0.35);
 }
 
 .config-alert {
@@ -483,9 +492,9 @@ textarea.config-input {
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  border-radius: 16px;
+  border-radius: 12px;
   border: 1px solid rgba(220, 38, 38, 0.35);
-  background: rgba(254, 226, 226, 0.92);
+  background: rgba(254, 226, 226, 0.8);
   color: #991b1b;
 }
 
@@ -519,11 +528,11 @@ textarea.config-input {
 }
 
 .toast {
-  padding: 14px 18px;
-  border-radius: 16px;
+  padding: 12px 16px;
+  border-radius: 12px;
   color: #fff;
   font-weight: 600;
-  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.25);
+  box-shadow: var(--shadow-level-2);
 }
 
 .toast--success {
@@ -538,16 +547,27 @@ textarea.config-input {
   background-color: #2563eb;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .config-form {
     grid-template-columns: 1fr;
   }
 
-  .config-form-field {
-    padding: 14px;
+  .catalog-card {
+    padding: 16px;
+  }
+}
+
+@media (max-width: 640px) {
+  .config-section,
+  .catalog-view__header {
+    padding: 16px;
   }
 
   .config-filter-bar {
     grid-template-columns: 1fr;
+  }
+
+  .config-table__scroll {
+    border-radius: 10px;
   }
 }

--- a/frontend-app/src/modules/configuracion/docs/components.mdx
+++ b/frontend-app/src/modules/configuracion/docs/components.mdx
@@ -34,12 +34,26 @@ Tabla responsiva con soporte para columnas personalizadas.
   rows={items}
   loading={false}
   emptyMessage="Sin registros"
+  pageSizeOptions={[10, 25, 50]}
   columns=[
     { key: 'nombre', label: 'Nombre' },
-    { key: 'estado', label: 'Estado', render: item => <EntityStatusBadge status={item.estado} /> }
+    { key: 'estado', label: 'Estado', render: item => <EntityStatusBadge status={item.estado} /> },
+    {
+      key: 'acciones',
+      label: 'Acciones',
+      render: (item) => (
+        <div className="catalog-row-actions">
+          <button type="button" onClick={() => onEdit(item)}>Editar</button>
+          <button type="button" onClick={() => onDelete(item)}>Eliminar</button>
+        </div>
+      ),
+    }
   ]
 />
 ```
+
+- `pageSizeOptions`: define los tamaños de página disponibles desde el selector integrado.
+- Las acciones pueden representarse con el contenedor utilitario `.catalog-row-actions` para mantener la alineación y el espaciado.
 
 ## CatalogFilterBar
 

--- a/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import CatalogFilterBar from '../components/CatalogFilterBar';
 import CatalogTable from '../components/CatalogTable';
 import type { CatalogTableColumn } from '../components/CatalogTable';
@@ -19,6 +19,7 @@ const ActividadesPage: React.FC = () => {
   const { showToast } = useToast();
   const [filters, setFilters] = useState<CatalogFilterState>({ search: '', status: 'todos' });
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingActividad, setEditingActividad] = useState<Actividad | null>(null);
   const form = useForm<ActividadFormValues>({ defaultValues: defaultActividadValues, validator: actividadValidator });
 
   const actividades = useMemo<Actividad[]>(() => {
@@ -34,34 +35,103 @@ const ActividadesPage: React.FC = () => {
     );
   }, [catalog.items, filters.search]);
 
-  const columns: CatalogTableColumn<Actividad>[] = [
-    {
-      key: 'nroAct',
-      label: 'N° de actividad',
-      width: '160px',
-      render: (actividad) => actividad.nroAct.toString().padStart(3, '0'),
-    },
-    { key: 'nombre', label: 'Nombre' },
-  ];
-
   const handleFiltersChange = (next: CatalogFilterState) =>
     setFilters({ search: next.search, status: 'todos', updatedBy: undefined });
 
   const handleSubmit = form.handleSubmit(async (values: ActividadFormValues) => {
     try {
-      await catalog.create({ nombre: values.nombre.trim() });
-      showToast('Actividad creada correctamente.', 'success');
+      if (editingActividad) {
+        await catalog.update(editingActividad.id, { nombre: values.nombre.trim() });
+        showToast('Actividad actualizada correctamente.', 'success');
+      } else {
+        await catalog.create({ nombre: values.nombre.trim() });
+        showToast('Actividad creada correctamente.', 'success');
+      }
       form.reset();
+      setEditingActividad(null);
       setIsFormOpen(false);
       await catalog.refetch();
     } catch (error) {
-      showToast('No se pudo crear la actividad. Intenta nuevamente.', 'error');
+      showToast('No se pudo guardar la actividad. Intenta nuevamente.', 'error');
     }
   });
+
+  const openCreateForm = useCallback(() => {
+    setEditingActividad(null);
+    form.reset();
+    setIsFormOpen(true);
+  }, [form]);
+
+  const handleEdit = useCallback(
+    (actividad: Actividad) => {
+      setEditingActividad(actividad);
+      form.reset({ nombre: actividad.nombre });
+      setIsFormOpen(true);
+    },
+    [form],
+  );
+
+  const handleDelete = useCallback(
+    async (actividad: Actividad) => {
+      const confirmed = window.confirm(`¿Deseas eliminar la actividad "${actividad.nombre}"?`);
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        await catalog.remove(actividad.id);
+        showToast('Actividad eliminada.', 'success');
+        await catalog.refetch();
+      } catch (error) {
+        showToast('No se pudo eliminar la actividad.', 'error');
+      }
+    },
+    [catalog, showToast],
+  );
+
+  const closeForm = useCallback(() => {
+    form.reset();
+    setEditingActividad(null);
+    setIsFormOpen(false);
+  }, [form]);
 
   const toggleButtonClassName = `config-button ${
     isFormOpen ? 'config-button--ghost' : 'config-button--primary'
   }`;
+
+  const toggleButtonLabel = isFormOpen
+    ? editingActividad
+      ? 'Cancelar edición'
+      : 'Cerrar formulario'
+    : 'Nueva actividad';
+
+  const columns: CatalogTableColumn<Actividad>[] = useMemo(
+    () => [
+      {
+        key: 'nroAct',
+        label: 'N° de actividad',
+        width: '160px',
+        render: (actividad) => actividad.nroAct.toString().padStart(3, '0'),
+      },
+      { key: 'nombre', label: 'Nombre' },
+      {
+        key: 'acciones',
+        label: 'Acciones',
+        width: '160px',
+        render: (actividad) => (
+          <div className="catalog-row-actions">
+            <button type="button" onClick={() => handleEdit(actividad)}>
+              Editar
+            </button>
+            <button type="button" onClick={() => handleDelete(actividad)}>
+              Eliminar
+            </button>
+          </div>
+        ),
+      },
+    ],
+    [handleDelete, handleEdit],
+  );
 
   return (
     <div className="catalog-view">
@@ -78,17 +148,23 @@ const ActividadesPage: React.FC = () => {
             <button
               type="button"
               className={toggleButtonClassName}
-              onClick={() => setIsFormOpen((open) => !open)}
+              onClick={() => {
+                if (isFormOpen) {
+                  closeForm();
+                } else {
+                  openCreateForm();
+                }
+              }}
               aria-expanded={isFormOpen}
               aria-controls="actividad-form"
             >
-              {isFormOpen ? 'Cerrar formulario' : 'Nueva actividad'}
+              {toggleButtonLabel}
             </button>
           </div>
         </header>
 
         {!isFormOpen && (
-          <>
+          <div className="catalog-card">
             <CatalogFilterBar
               value={filters}
               onChange={handleFiltersChange}
@@ -113,15 +189,19 @@ const ActividadesPage: React.FC = () => {
               loading={catalog.isLoading}
               emptyMessage="No hay actividades registradas."
             />
-          </>
+          </div>
         )}
       </section>
 
       {isFormOpen && (
         <ProtectedRoute permissions={[activeRoute?.meta.permissions.write ?? 'catalogos.write']}>
           <FormSection
-            title="Crear actividad"
-            description="El número de actividad se asigna automáticamente al guardar."
+            title={editingActividad ? 'Editar actividad' : 'Crear actividad'}
+            description={
+              editingActividad
+                ? 'Actualiza el nombre para mantener el catálogo consistente.'
+                : 'El número de actividad se asigna automáticamente al guardar.'
+            }
           >
             <form id="actividad-form" onSubmit={handleSubmit} noValidate className="config-form">
               <div className="config-form-field">
@@ -141,10 +221,8 @@ const ActividadesPage: React.FC = () => {
 
               <FormActions
                 isSubmitting={form.formState.isSubmitting}
-                onCancel={() => {
-                  form.reset();
-                  setIsFormOpen(false);
-                }}
+                onCancel={closeForm}
+                submitLabel={editingActividad ? 'Guardar cambios' : undefined}
               />
             </form>
           </FormSection>


### PR DESCRIPTION
## Summary
- Restyle the application shell with a collapsible side drawer and a calmer Material 3 inspired palette.
- Simplify the configuration module surfaces, consolidating filters, tables and pagination into unified cards with responsive fixes.
- Add inline edit/delete actions, selectable page sizes for catalog tables, and update the shared documentation accordingly.

## Testing
- npm run build *(fails: missing TypeScript definitions because the registry denied dependency downloads in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a2230a9c8330bc9500a9e2f8f520