### PR TITLE
feat: mejorar navegación lateral y confirmaciones

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -11,6 +11,12 @@
   --color-primary-container: #e3efff;
   --color-on-primary: #ffffff;
   --color-on-primary-container: #0b2c4a;
+  --color-navbar-bg: linear-gradient(135deg, #0b1727 0%, #111c2d 50%, #1d2b44 100%);
+  --color-navbar-text: #e2e8f0;
+  --color-navbar-subtext: #cbd5f5;
+  --color-navbar-accent: #60a5fa;
+  --color-danger: #dc2626;
+  --color-danger-hover: #b91c1c;
   --shadow-level-1: 0 10px 30px rgba(15, 23, 42, 0.1);
   --shadow-level-2: 0 16px 40px rgba(15, 23, 42, 0.14);
   color-scheme: light;
@@ -36,21 +42,22 @@ body {
 
 .app-navbar {
   width: 100%;
-  background: var(--color-surface-alt);
-  border-bottom: 1px solid var(--color-outline);
+  background: var(--color-navbar-bg);
   position: sticky;
   top: 0;
   z-index: 10;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .app-navbar__content {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 16px 24px;
+  padding: 18px 24px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
+  color: var(--color-navbar-text);
 }
 
 .app-navbar__brand {
@@ -66,9 +73,9 @@ body {
   display: grid;
   place-items: center;
   font-size: 1.5rem;
-  background: var(--color-primary-container);
-  color: var(--color-on-primary-container);
-  border: 1px solid var(--color-outline);
+  background: rgba(255, 255, 255, 0.1);
+  color: #f8fafc;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .app-navbar__headline {
@@ -83,19 +90,20 @@ body {
   letter-spacing: 0.12em;
   font-size: 0.7rem;
   font-weight: 600;
-  color: var(--color-primary-variant);
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .app-navbar__title {
   margin: 0;
-  font-size: 1.6rem;
-  font-weight: 650;
+  font-size: 1.7rem;
+  font-weight: 680;
+  color: var(--color-navbar-text);
 }
 
 .app-navbar__subtitle {
   margin: 0;
   font-size: 0.95rem;
-  color: var(--color-text-secondary);
+  color: var(--color-navbar-subtext);
   max-width: 460px;
 }
 
@@ -107,26 +115,35 @@ body {
 }
 
 .app-navbar__action {
-  border: 1px solid var(--color-outline);
+  border: 1px solid rgba(226, 232, 240, 0.25);
   border-radius: 12px;
-  padding: 10px 16px;
+  padding: 10px 18px;
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
-  color: var(--color-primary-variant);
-  background: transparent;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  color: var(--color-navbar-text);
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(8px);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 .app-navbar__action:hover {
-  background: rgba(20, 94, 168, 0.08);
-  border-color: var(--color-primary-variant);
+  background: rgba(99, 102, 241, 0.18);
+  border-color: rgba(96, 165, 250, 0.6);
+  color: var(--color-navbar-accent);
+  transform: translateY(-1px);
 }
 
 .app-navbar__action--primary {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: var(--color-on-primary);
+  background: rgba(59, 130, 246, 0.85);
+  border-color: rgba(96, 165, 250, 0.9);
+  color: #f8fafc;
+}
+
+.app-navbar__action--primary:hover {
+  background: rgba(37, 99, 235, 0.92);
+  border-color: rgba(59, 130, 246, 0.95);
+  color: #f8fafc;
 }
 
 .app-shell__content {
@@ -139,9 +156,13 @@ body {
   max-width: 1200px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 24px;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    'toggle toggle'
+    'sidebar main';
+  gap: 20px 24px;
   align-items: start;
+  position: relative;
 }
 
 .app-sidebar__toggle {
@@ -156,21 +177,149 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
+  grid-area: toggle;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.app-sidebar__toggle:hover {
+  background: rgba(20, 94, 168, 0.1);
+  border-color: var(--color-primary-variant);
+  color: var(--color-primary-variant);
 }
 
 .app-sidebar {
   border: 1px solid var(--color-outline);
   background: var(--color-surface-alt);
-  border-radius: 16px;
-  padding: 20px 18px;
+  border-radius: 20px;
   box-shadow: var(--shadow-level-1);
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  transition: width 0.25s ease, transform 0.3s ease;
+  grid-area: sidebar;
+  position: relative;
+  overflow: hidden;
+}
+
+.app-sidebar[data-expanded='false'] {
+  width: 92px;
+}
+
+.app-sidebar[data-compact='true'] {
+  position: fixed;
+  top: 24px;
+  left: 16px;
+  bottom: 24px;
+  transform: translateX(-120%);
+  width: min(320px, calc(100% - 32px));
+  z-index: 20;
+}
+
+.app-sidebar[data-compact='true'][data-visible='true'] {
+  transform: translateX(0);
+}
+
+.app-sidebar__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.app-sidebar__content {
+  padding: 22px 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.app-sidebar[data-expanded='false'] .app-sidebar__content {
+  align-items: center;
+  padding-inline: 16px;
+}
+
+.app-sidebar__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.app-sidebar__nav-item {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  text-align: left;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.app-sidebar__nav-item:hover,
+.app-sidebar__nav-item:focus-visible {
+  background: rgba(20, 94, 168, 0.08);
+  outline: none;
+  color: var(--color-primary-variant);
+  transform: translateX(2px);
+}
+
+.app-sidebar__nav-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: rgba(20, 94, 168, 0.1);
+  color: var(--color-primary-variant);
+  flex-shrink: 0;
+}
+
+.app-sidebar__nav-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.app-sidebar__nav-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.app-sidebar__nav-label {
+  font-weight: 650;
+  font-size: 0.95rem;
+}
+
+.app-sidebar__nav-description {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+  line-height: 1.3;
+}
+
+.app-sidebar[data-expanded='false'] .app-sidebar__nav-text {
   display: none;
 }
 
-.app-sidebar[data-open='true'] {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.app-sidebar[data-expanded='false'] .app-sidebar__nav-item {
+  justify-content: center;
+  padding: 12px;
+}
+
+.app-sidebar[data-expanded='false'] .app-sidebar__nav-icon {
+  background: rgba(20, 94, 168, 0.15);
 }
 
 .app-sidebar__section {
@@ -182,6 +331,10 @@ body {
 .app-sidebar__section.is-open {
   border-color: var(--color-outline);
   background: rgba(20, 94, 168, 0.05);
+}
+
+.app-sidebar[data-expanded='false'] .app-sidebar__section {
+  display: none;
 }
 
 .app-sidebar__section-toggle {
@@ -205,6 +358,10 @@ body {
   padding: 0 8px 12px;
   font-size: 0.9rem;
   color: var(--color-text-secondary);
+}
+
+.app-sidebar[data-expanded='false'] .app-sidebar__section-body {
+  display: none;
 }
 
 .app-sidebar__description {
@@ -266,30 +423,43 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  background: var(--color-surface-alt);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: var(--shadow-level-1);
+  grid-area: main;
 }
 
 @media (min-width: 1024px) {
   .app-shell__content {
-    padding: 32px 24px 56px;
-  }
-
-  .app-layout {
-    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
-  }
-
-  .app-sidebar__toggle {
-    display: none;
-  }
-
-  .app-sidebar {
-    display: flex;
+    padding-inline: 24px;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 1023px) {
+  .app-layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'toggle'
+      'main';
+  }
+
+  .app-sidebar {
+    box-shadow: var(--shadow-level-2);
+  }
+
+  .app-main {
+    padding: 20px;
+  }
+
+  .app-sidebar__toggle {
+    justify-self: flex-start;
+  }
+
   .app-navbar__content {
     flex-direction: column;
     align-items: flex-start;
+    gap: 18px;
   }
 
   .app-navbar__actions {
@@ -300,5 +470,15 @@ body {
   .app-navbar__action {
     flex: 1 1 auto;
     text-align: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell__content {
+    padding-inline: 12px;
+  }
+
+  .app-main {
+    padding: 18px;
   }
 }

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -1,20 +1,136 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ConfiguracionModule from './modules/configuracion';
 import './App.css';
 
+type NavItem = {
+  id: string;
+  label: string;
+  description: string;
+  icon: JSX.Element;
+};
+
+const buildNavigation = (): NavItem[] => [
+  {
+    id: 'overview',
+    label: 'Panel general',
+    description: 'Monitorea el estado global de los catálogos y sus dependencias.',
+    icon: <SidebarIcon name="dashboard" />,
+  },
+  {
+    id: 'parametros',
+    label: 'Parámetros generales',
+    description: 'Ajusta políticas y parámetros maestros del sistema.',
+    icon: <SidebarIcon name="sliders" />,
+  },
+  {
+    id: 'centros',
+    label: 'Centros de producción',
+    description: 'Administra ubicaciones, responsables y capacidades.',
+    icon: <SidebarIcon name="factory" />,
+  },
+  {
+    id: 'empleados',
+    label: 'Personal operativo',
+    description: 'Gestiona credenciales, roles y perfiles por área.',
+    icon: <SidebarIcon name="users" />,
+  },
+  {
+    id: 'actividades',
+    label: 'Actividades',
+    description: 'Define etapas de producción y tareas dependientes.',
+    icon: <SidebarIcon name="workflow" />,
+  },
+];
+
+function SidebarIcon({ name }: { name: 'dashboard' | 'sliders' | 'factory' | 'users' | 'workflow' }) {
+  switch (name) {
+    case 'dashboard':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M4 13h6v7H4zm10-9h6v16h-6zM4 4h6v7H4zm10 9h6v7h-6z" fill="currentColor" />
+        </svg>
+      );
+    case 'sliders':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M9 5a2 2 0 1 1-4 0H3V3h2a2 2 0 1 1 4 0h12v2H9zm8 8a2 2 0 1 1 4 0h2v2h-2a2 2 0 1 1-4 0H3v-2h14zm-8 6a2 2 0 1 1-4 0H3v-2h2a2 2 0 1 1 4 0h12v2H9z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'factory':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M3 21V9l6 4V9l6 4V5l6 3v13H3zm12-7h2v-2h-2zm0 4h2v-2h-2zm-4-4h2v-2h-2zm0 4h2v-2h-2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'users':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M16 11a4 4 0 1 0-8 0 4 4 0 0 0 8 0zm-4 6c-4.418 0-8 1.79-8 4v2h16v-2c0-2.21-3.582-4-8-4zm8-7a3 3 0 1 0-6 0 3 3 0 0 0 6 0zm-1 7c1.298.607 2 1.398 2 2.3V21h-3v-2c0-.673-.342-1.3-.959-1.87z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'workflow':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M7 4h10v6H7zm12 14h-4v-4h-2v4H5v-6h4v-4h2v4h6V8h2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
 function App() {
-  const [isDrawerOpen, setIsDrawerOpen] = useState(true);
+  const [isCompactViewport, setIsCompactViewport] = useState(false);
+  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
+  const [isSidebarVisible, setIsSidebarVisible] = useState(true);
   const [openSections, setOpenSections] = useState({ overview: true, shortcuts: false });
 
   useEffect(() => {
     const handleResize = () => {
-      setIsDrawerOpen(window.innerWidth >= 1024);
+      const compact = window.innerWidth < 1024;
+      setIsCompactViewport(compact);
+      setIsSidebarVisible(!compact);
+      setIsSidebarExpanded(!compact);
     };
 
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  const navigationItems = useMemo(() => buildNavigation(), []);
+
+  const toggleSidebar = () => {
+    if (isCompactViewport) {
+      setIsSidebarVisible((visible) => {
+        const nextVisible = !visible;
+        if (nextVisible) {
+          setIsSidebarExpanded(true);
+        }
+        return nextVisible;
+      });
+    } else {
+      setIsSidebarExpanded((expanded) => !expanded);
+    }
+  };
+
+  const closeSidebar = () => {
+    if (isCompactViewport) {
+      setIsSidebarVisible(false);
+    }
+  };
 
   const toggleSection = (section: keyof typeof openSections) => {
     setOpenSections((current) => ({ ...current, [section]: !current[section] }));
@@ -50,81 +166,118 @@ function App() {
           <button
             type="button"
             className="app-sidebar__toggle"
-            onClick={() => setIsDrawerOpen((open) => !open)}
-            aria-expanded={isDrawerOpen}
+            onClick={toggleSidebar}
+            aria-expanded={isCompactViewport ? isSidebarVisible : isSidebarExpanded}
             aria-controls="app-sidebar"
           >
-            {isDrawerOpen ? 'Ocultar panel' : 'Mostrar panel'}
+            {isCompactViewport
+              ? isSidebarVisible
+                ? 'Cerrar panel'
+                : 'Abrir panel'
+              : isSidebarExpanded
+                ? 'Contraer panel'
+                : 'Expandir panel'}
           </button>
+
+          {isCompactViewport && isSidebarVisible && (
+            <button type="button" className="app-sidebar__backdrop" aria-label="Cerrar panel" onClick={closeSidebar} />
+          )}
 
           <aside
             id="app-sidebar"
             className="app-sidebar"
             aria-label="Panel contextual de configuración"
-            data-open={isDrawerOpen}
+            data-expanded={isSidebarExpanded}
+            data-visible={isSidebarVisible}
+            data-compact={isCompactViewport}
           >
-            <section className={`app-sidebar__section ${openSections.overview ? 'is-open' : ''}`}>
-              <button
-                type="button"
-                className="app-sidebar__section-toggle"
-                onClick={() => toggleSection('overview')}
-                aria-expanded={openSections.overview}
-              >
-                <span>Resumen del panel</span>
-                <span aria-hidden="true">{openSections.overview ? '−' : '+'}</span>
-              </button>
-              <div className="app-sidebar__section-body" hidden={!openSections.overview}>
-                <p className="app-sidebar__description">
-                  Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de publicar
-                  cambios.
-                </p>
-                <ul className="app-sidebar__stats">
-                  <li className="app-sidebar__stat">
-                    <span className="app-sidebar__stat-value">4</span>
-                    <span className="app-sidebar__stat-label">Catálogos activos</span>
-                  </li>
-                  <li className="app-sidebar__stat">
-                    <span className="app-sidebar__stat-value">3</span>
-                    <span className="app-sidebar__stat-label">Dependencias críticas</span>
-                  </li>
-                  <li className="app-sidebar__stat">
-                    <span className="app-sidebar__stat-value">En línea</span>
-                    <span className="app-sidebar__stat-label">Estado de sincronización</span>
-                  </li>
+            <div className="app-sidebar__content">
+              <nav className="app-sidebar__nav" aria-label="Secciones principales">
+                <ul>
+                  {navigationItems.map((item) => (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        className="app-sidebar__nav-item"
+                        aria-label={item.label}
+                        tabIndex={0}
+                      >
+                        <span className="app-sidebar__nav-icon" aria-hidden="true">
+                          {item.icon}
+                        </span>
+                        <span className="app-sidebar__nav-text">
+                          <span className="app-sidebar__nav-label">{item.label}</span>
+                          <span className="app-sidebar__nav-description">{item.description}</span>
+                        </span>
+                      </button>
+                    </li>
+                  ))}
                 </ul>
-              </div>
-            </section>
+              </nav>
 
-            <section className={`app-sidebar__section ${openSections.shortcuts ? 'is-open' : ''}`}>
-              <button
-                type="button"
-                className="app-sidebar__section-toggle"
-                onClick={() => toggleSection('shortcuts')}
-                aria-expanded={openSections.shortcuts}
-              >
-                <span>Atajos recomendados</span>
-                <span aria-hidden="true">{openSections.shortcuts ? '−' : '+'}</span>
-              </button>
-              <div className="app-sidebar__section-body" hidden={!openSections.shortcuts}>
-                <ul className="app-sidebar__links">
-                  <li>
-                    <button type="button" className="app-sidebar__link">
-                      Revisar dependencias
-                    </button>
-                  </li>
-                  <li>
-                    <button type="button" className="app-sidebar__link">
-                      Programar sincronización
-                    </button>
-                  </li>
-                  <li>
-                    <button type="button" className="app-sidebar__link">
-                      Descargar respaldo
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            </section>
+              <section className={`app-sidebar__section ${openSections.overview ? 'is-open' : ''}`}>
+                <button
+                  type="button"
+                  className="app-sidebar__section-toggle"
+                  onClick={() => toggleSection('overview')}
+                  aria-expanded={openSections.overview}
+                >
+                  <span>Resumen del panel</span>
+                  <span aria-hidden="true">{openSections.overview ? '−' : '+'}</span>
+                </button>
+                <div className="app-sidebar__section-body" hidden={!openSections.overview}>
+                  <p className="app-sidebar__description">
+                    Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de
+                    publicar cambios.
+                  </p>
+                  <ul className="app-sidebar__stats">
+                    <li className="app-sidebar__stat">
+                      <span className="app-sidebar__stat-value">4</span>
+                      <span className="app-sidebar__stat-label">Catálogos activos</span>
+                    </li>
+                    <li className="app-sidebar__stat">
+                      <span className="app-sidebar__stat-value">3</span>
+                      <span className="app-sidebar__stat-label">Dependencias críticas</span>
+                    </li>
+                    <li className="app-sidebar__stat">
+                      <span className="app-sidebar__stat-value">En línea</span>
+                      <span className="app-sidebar__stat-label">Estado de sincronización</span>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+
+              <section className={`app-sidebar__section ${openSections.shortcuts ? 'is-open' : ''}`}>
+                <button
+                  type="button"
+                  className="app-sidebar__section-toggle"
+                  onClick={() => toggleSection('shortcuts')}
+                  aria-expanded={openSections.shortcuts}
+                >
+                  <span>Atajos recomendados</span>
+                  <span aria-hidden="true">{openSections.shortcuts ? '−' : '+'}</span>
+                </button>
+                <div className="app-sidebar__section-body" hidden={!openSections.shortcuts}>
+                  <ul className="app-sidebar__links">
+                    <li>
+                      <button type="button" className="app-sidebar__link">
+                        Revisar dependencias
+                      </button>
+                    </li>
+                    <li>
+                      <button type="button" className="app-sidebar__link">
+                        Programar sincronización
+                      </button>
+                    </li>
+                    <li>
+                      <button type="button" className="app-sidebar__link">
+                        Descargar respaldo
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+            </div>
           </aside>
 
           <main className="app-main">

--- a/frontend-app/src/app/layout/AppLayout.tsx
+++ b/frontend-app/src/app/layout/AppLayout.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 import AppHeader from './AppHeader';
 import AppSidebar from './AppSidebar';
 import AppContent from './AppContent';
-import Box from '@mui/material/Box';
 
 const AppLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+  <div style={{ display: 'flex', minHeight: '100vh' }}>
     <AppSidebar />
-    <Box sx={{ flex: 1, flexDirection: 'column', display: 'flex' }}>
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
       <AppHeader />
       <AppContent>{children}</AppContent>
-    </Box>
-  </Box>
+    </div>
+  </div>
 );
 
 export default AppLayout;

--- a/frontend-app/src/app/routes.tsx
+++ b/frontend-app/src/app/routes.tsx
@@ -1,8 +1,5 @@
 import { lazy } from 'react';
 import { RouteObject } from 'react-router-dom';
-import HomeIcon from '@mui/icons-material/Home';
-import SettingsIcon from '@mui/icons-material/Settings';
-import TableChartIcon from '@mui/icons-material/TableChart';
 
 // Ejemplo de lazy loading de páginas
 const HomePage = lazy(() => import('@/modules/home/HomePage'));
@@ -24,17 +21,51 @@ export const appRoutes: AppRouteObject[] = [
   {
     path: '/',
     element: <HomePage />,
-    meta: { title: 'Inicio', icon: <HomeIcon /> },
+    meta: { title: 'Inicio', icon: <RouteIcon name="home" /> },
   },
   {
     path: '/configuracion',
     element: <ConfigPage />,
-    meta: { title: 'Configuración', icon: <SettingsIcon /> },
+    meta: { title: 'Configuración', icon: <RouteIcon name="settings" /> },
   },
   {
     path: '/reportes',
     element: <ReportsPage />,
-    meta: { title: 'Reportes', icon: <TableChartIcon /> },
+    meta: { title: 'Reportes', icon: <RouteIcon name="reports" /> },
   },
   // Agregar más rutas y dominios según system-overview
 ];
+
+function RouteIcon({ name }: { name: 'home' | 'settings' | 'reports' }) {
+  switch (name) {
+    case 'home':
+      return (
+        <svg viewBox="0 0 24 24" width={20} height={20} aria-hidden="true" focusable="false">
+          <path
+            d="M4 10.5 12 4l8 6.5V21h-6v-5h-4v5H4z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'settings':
+      return (
+        <svg viewBox="0 0 24 24" width={20} height={20} aria-hidden="true" focusable="false">
+          <path
+            d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7 7 0 0 0-1.63-.94l-.36-2.54A.5.5 0 0 0 14.9 2h-3.8a.5.5 0 0 0-.5.42l-.36 2.54a7 7 0 0 0-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 8.48a.5.5 0 0 0 .12.64l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94L2.82 13.6a.5.5 0 0 0-.12.64l1.92 3.32a.5.5 0 0 0 .6.22l2.39-.96c.5.39 1.05.72 1.63.94l.36 2.54a.5.5 0 0 0 .5.42h3.8a.5.5 0 0 0 .5-.42l.36-2.54c.58-.22 1.13-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64zm-7.14 1.56a3 3 0 1 1 0-6 3 3 0 0 1 0 6z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'reports':
+      return (
+        <svg viewBox="0 0 24 24" width={20} height={20} aria-hidden="true" focusable="false">
+          <path
+            d="M5 3h14a2 2 0 0 1 2 2v14l-4-3-4 3-4-3-4 3V5a2 2 0 0 1 2-2zm2 4v4h2V7zm4 3v3h2v-3zm4-5v8h2V5z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}

--- a/frontend-app/src/modules/configuracion/components/ConfirmDialog.tsx
+++ b/frontend-app/src/modules/configuracion/components/ConfirmDialog.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useId, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import '../configuracion.css';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  description,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  onCancel,
+  onConfirm,
+}) => {
+  const titleId = useId();
+  const descriptionId = useId();
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onCancel]);
+
+  useEffect(() => {
+    if (open) {
+      cancelButtonRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="config-modal__backdrop" role="presentation" onClick={onCancel}>
+      <div
+        className="config-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="config-modal__header">
+          <div className="config-modal__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path
+                d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 14h-2v-2h2zm0-4h-2V7h2z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <h2 id={titleId} className="config-modal__title">
+            {title}
+          </h2>
+        </header>
+        <p id={descriptionId} className="config-modal__description">
+          {description}
+        </p>
+        <div className="config-modal__actions">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            className="config-modal__button"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button type="button" className="config-modal__button config-modal__button--danger" onClick={onConfirm}>
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default ConfirmDialog;

--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -420,18 +420,45 @@ textarea.config-input {
   gap: 8px;
 }
 
-.catalog-row-actions button {
+.catalog-row-actions__edit,
+.catalog-row-actions__delete {
   border: none;
-  background: none;
-  color: var(--color-primary-variant);
   font-weight: 600;
   cursor: pointer;
-  padding: 4px 6px;
-  border-radius: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease;
 }
 
-.catalog-row-actions button:hover {
-  background: rgba(20, 94, 168, 0.1);
+.catalog-row-actions__edit {
+  background: rgba(14, 116, 144, 0.12);
+  color: #0f766e;
+  box-shadow: inset 0 0 0 1px rgba(14, 116, 144, 0.25);
+}
+
+.catalog-row-actions__edit:hover {
+  background: rgba(13, 148, 136, 0.16);
+  transform: translateY(-1px);
+}
+
+.catalog-row-actions__delete {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+  box-shadow: inset 0 0 0 1px rgba(220, 38, 38, 0.25);
+}
+
+.catalog-row-actions__delete:hover {
+  background: rgba(220, 38, 38, 0.16);
+  transform: translateY(-1px);
+}
+
+.catalog-row-actions__icon {
+  display: inline-flex;
+  align-items: center;
 }
 
 .badge {
@@ -545,6 +572,103 @@ textarea.config-input {
 
 .toast--info {
   background-color: #2563eb;
+}
+
+.config-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 100;
+}
+
+.config-modal {
+  background: var(--color-surface-alt);
+  border-radius: 18px;
+  width: min(420px, 100%);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-level-2);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.config-modal__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.config-modal__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+  display: grid;
+  place-items: center;
+}
+
+.config-modal__icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.config-modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 650;
+  color: var(--color-text-primary);
+}
+
+.config-modal__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.config-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.config-modal__button {
+  border-radius: 10px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface);
+  padding: 8px 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.15s ease, border-color 0.2s ease;
+}
+
+.config-modal__button:hover {
+  background: rgba(20, 94, 168, 0.08);
+  border-color: var(--color-primary-variant);
+}
+
+.config-modal__button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.config-modal__button--danger {
+  background: rgba(220, 38, 38, 0.9);
+  border-color: rgba(185, 28, 28, 0.85);
+  color: #ffffff;
+}
+
+.config-modal__button--danger:hover {
+  background: var(--color-danger-hover);
+  transform: translateY(-1px);
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- modernizar la barra superior y el panel lateral con un sidedrawer colapsable que conserva iconos en modo compacto
- añadir un componente de diálogo de confirmación reutilizable con estilos acordes al panel de configuración
- aplicar los nuevos botones de acción y confirmaciones a los catálogos de parámetros, centros, empleados y actividades

## Testing
- npm run build *(falla: el entorno no puede resolver los tipos de `vite/client` y `node` porque el paquete `vite` no está disponible en el registro en este entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a78aa3808330bd2655a5c63e6971