### PR TITLE
Move sidebar toggle into panel and expand content width

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -79,18 +79,24 @@ body {
   min-width: 0;
 }
 
-.app-navbar__toggle {
+.app-toggle-button {
   width: 44px;
   height: 44px;
   border-radius: 12px;
-  border: 1px solid rgba(226, 232, 240, 0.25);
-  background: rgba(15, 23, 42, 0.35);
-  color: var(--color-navbar-text);
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.app-navbar__toggle {
+  border: 1px solid rgba(226, 232, 240, 0.25);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-navbar-text);
 }
 
 .app-navbar__toggle:hover {
@@ -105,7 +111,7 @@ body {
   outline-offset: 2px;
 }
 
-.app-navbar__toggle-icon {
+.app-toggle-button__icon {
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
@@ -115,7 +121,7 @@ body {
   height: 16px;
 }
 
-.app-navbar__toggle-icon span {
+.app-toggle-button__icon span {
   display: block;
   width: 100%;
   height: 2px;
@@ -124,15 +130,15 @@ body {
   transition: transform 0.25s ease, opacity 0.25s ease;
 }
 
-.app-navbar__toggle[data-open='true'] .app-navbar__toggle-icon span:nth-child(1) {
+.app-toggle-button[data-open='true'] .app-toggle-button__icon span:nth-child(1) {
   transform: translateY(7px) rotate(45deg);
 }
 
-.app-navbar__toggle[data-open='true'] .app-navbar__toggle-icon span:nth-child(2) {
+.app-toggle-button[data-open='true'] .app-toggle-button__icon span:nth-child(2) {
   opacity: 0;
 }
 
-.app-navbar__toggle[data-open='true'] .app-navbar__toggle-icon span:nth-child(3) {
+.app-toggle-button[data-open='true'] .app-toggle-button__icon span:nth-child(3) {
   transform: translateY(-7px) rotate(-45deg);
 }
 
@@ -231,21 +237,16 @@ body {
 .app-shell__content {
   flex: 1;
   width: 100%;
-  padding: 24px 16px 48px 0;
+  padding: 24px 24px 48px;
 }
 
 .app-layout {
-  max-width: 1200px;
-  margin-left: 0;
-  margin-right: auto;
   width: 100%;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   grid-template-areas: 'sidebar main';
   gap: 20px 24px;
   align-items: start;
-  position: relative;
-  padding-right: 16px;
 }
 
 .app-sidebar {
@@ -298,6 +299,40 @@ body {
   gap: 20px;
   height: 100%;
   overflow-y: auto;
+}
+
+.app-sidebar__controls {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.app-sidebar[data-expanded='false'] .app-sidebar__controls {
+  justify-content: center;
+}
+
+.app-sidebar__toggle {
+  border: 1px solid rgba(20, 94, 168, 0.2);
+  background: rgba(20, 94, 168, 0.08);
+  color: var(--color-primary-variant);
+}
+
+.app-sidebar__toggle:hover {
+  background: rgba(20, 94, 168, 0.16);
+  border-color: rgba(20, 94, 168, 0.28);
+  color: var(--color-primary);
+  transform: translateY(-1px);
+}
+
+.app-sidebar__toggle:focus-visible {
+  outline: 2px solid rgba(20, 94, 168, 0.45);
+  outline-offset: 2px;
+}
+
+.app-sidebar__toggle[data-open='true'] {
+  background: rgba(20, 94, 168, 0.22);
+  border-color: rgba(20, 94, 168, 0.4);
+  color: var(--color-on-primary-container);
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__content {
@@ -535,7 +570,7 @@ body {
 
 @media (max-width: 640px) {
   .app-shell__content {
-    padding: 20px 12px 48px 0;
+    padding: 20px 16px 48px;
   }
 
   .app-main {

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -150,23 +150,25 @@ function App() {
       <header className="app-navbar">
         <div className="app-navbar__content">
           <div className="app-navbar__start">
-            <button
-              type="button"
-              className="app-navbar__toggle"
-              onClick={toggleSidebar}
-              aria-expanded={isSidebarOpen}
-              aria-controls="app-sidebar"
-              aria-label={toggleLabel}
-              title={toggleLabel}
-              data-open={isSidebarOpen}
-            >
-              <span className="sr-only">{toggleLabel}</span>
-              <span className="app-navbar__toggle-icon" aria-hidden="true">
-                <span />
-                <span />
-                <span />
-              </span>
-            </button>
+            {isCompactViewport && (
+              <button
+                type="button"
+                className="app-navbar__toggle app-toggle-button"
+                onClick={toggleSidebar}
+                aria-expanded={isSidebarOpen}
+                aria-controls="app-sidebar"
+                aria-label={toggleLabel}
+                title={toggleLabel}
+                data-open={isSidebarOpen}
+              >
+                <span className="sr-only">{toggleLabel}</span>
+                <span className="app-toggle-button__icon" aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                </span>
+              </button>
+            )}
 
             <div className="app-navbar__brand">
               <div className="app-navbar__logo" aria-hidden="true">
@@ -205,6 +207,25 @@ function App() {
             data-compact={isCompactViewport}
           >
             <div className="app-sidebar__content">
+              <div className="app-sidebar__controls">
+                <button
+                  type="button"
+                  className="app-sidebar__toggle app-toggle-button"
+                  onClick={toggleSidebar}
+                  aria-expanded={isSidebarOpen}
+                  aria-controls="app-sidebar"
+                  aria-label={toggleLabel}
+                  title={toggleLabel}
+                  data-open={isSidebarOpen}
+                >
+                  <span className="sr-only">{toggleLabel}</span>
+                  <span className="app-toggle-button__icon" aria-hidden="true">
+                    <span />
+                    <span />
+                    <span />
+                  </span>
+                </button>
+              </div>
               <nav className="app-sidebar__nav" aria-label="Secciones principales">
                 <ul>
                   {navigationItems.map((item) => (


### PR DESCRIPTION
## Summary
- render the sidebar toggle control inside the sidebar panel on wide viewports while keeping the compact toggle in the navbar
- add shared styling for the toggle button and adjust layout spacing so the main content stretches across the available width

## Testing
- npm install --no-progress *(fails: 403 Forbidden when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e559b661a88330a9a9455bf7b0f098