### PR TITLE
Hide sidebar scrollbar

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -299,6 +299,13 @@ body {
   gap: 20px;
   height: 100%;
   overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.app-sidebar__content::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 .app-sidebar__controls {


### PR DESCRIPTION
## Summary
- hide the scrollbar in the sidebar content area while preserving scroll behavior

## Testing
- npm test *(fails: TS2307 Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e55cad0b108330a90c3abbaf31bfe8