### PR TITLE
Add access to operación diaria workflows

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -195,6 +195,43 @@ body {
   max-width: 460px;
 }
 
+.app-navbar__domains {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.app-navbar__domain-button {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+  padding: 6px 16px;
+  background: rgba(15, 23, 42, 0.2);
+  color: var(--color-navbar-text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.app-navbar__domain-button:hover {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.45);
+  color: var(--color-navbar-accent);
+  transform: translateY(-1px);
+}
+
+.app-navbar__domain-button[data-active='true'] {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(96, 165, 250, 0.75);
+  color: #f8fafc;
+}
+
+.app-navbar__domain-button:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.9);
+  outline-offset: 2px;
+}
+
 .app-navbar__actions {
   display: flex;
   gap: 12px;
@@ -377,6 +414,17 @@ body {
   outline: none;
   color: var(--color-primary-variant);
   transform: translateX(2px);
+}
+
+.app-sidebar__nav-item[data-active='true'] {
+  background: rgba(20, 94, 168, 0.16);
+  color: var(--color-primary-variant);
+  box-shadow: inset 0 0 0 1px rgba(20, 94, 168, 0.18);
+}
+
+.app-sidebar__nav-item[data-active='true'] .app-sidebar__nav-icon {
+  background: rgba(20, 94, 168, 0.22);
+  color: var(--color-primary);
 }
 
 .app-sidebar__nav-icon {

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import ConfiguracionModule from './modules/configuracion';
+import OperacionModule from './modules/operacion';
+import { buildOperacionRoutes } from './modules/operacion/routes';
+import type { OperacionModulo } from './modules/operacion/types';
 import './App.css';
 
 type NavItem = {
@@ -8,8 +11,49 @@ type NavItem = {
   description: string;
   icon: JSX.Element;
 };
+type DomainKey = 'configuracion' | 'operacion';
 
-const buildNavigation = (): NavItem[] => [
+type DomainAction = {
+  label: string;
+  variant?: 'primary' | 'default';
+};
+
+type SidebarStat = {
+  value: string;
+  label: string;
+};
+
+type DomainConfig = {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  logo: string;
+  actions: DomainAction[];
+  overview: {
+    description: string;
+    stats: SidebarStat[];
+  };
+  shortcuts: string[];
+};
+
+type SidebarIconName =
+  | 'dashboard'
+  | 'sliders'
+  | 'factory'
+  | 'users'
+  | 'workflow'
+  | 'consumos'
+  | 'producciones'
+  | 'litros'
+  | 'perdidas'
+  | 'sobrantes';
+
+type EnhancedNavItem = NavItem & {
+  onSelect?: () => void;
+  isActive?: boolean;
+};
+
+const buildConfiguracionNavigation = (): EnhancedNavItem[] => [
   {
     id: 'overview',
     label: 'Panel general',
@@ -42,7 +86,56 @@ const buildNavigation = (): NavItem[] => [
   },
 ];
 
-function SidebarIcon({ name }: { name: 'dashboard' | 'sliders' | 'factory' | 'users' | 'workflow' }) {
+const domainConfigs: Record<DomainKey, DomainConfig> = {
+  configuracion: {
+    eyebrow: 'Suite Herbal ERP',
+    title: 'Configuración y catálogos',
+    subtitle: 'Administra los catálogos maestros y parámetros generales utilizados por los módulos operativos.',
+    logo: '🌿',
+    actions: [
+      { label: 'Agregar catálogo', variant: 'primary' },
+      { label: 'Centro de ayuda' },
+    ],
+    overview: {
+      description:
+        'Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de publicar cambios.',
+      stats: [
+        { value: '4', label: 'Catálogos activos' },
+        { value: '3', label: 'Dependencias críticas' },
+        { value: 'En línea', label: 'Estado de sincronización' },
+      ],
+    },
+    shortcuts: ['Revisar dependencias', 'Programar sincronización', 'Descargar respaldo'],
+  },
+  operacion: {
+    eyebrow: 'Suite Herbal ERP · Operación',
+    title: 'Operación diaria',
+    subtitle:
+      'Captura y monitorea consumos, producciones, litros, pérdidas y sobrantes con trazabilidad y cierres controlados.',
+    logo: '🛠️',
+    actions: [
+      { label: 'Nueva importación', variant: 'primary' },
+      { label: 'Ver bitácoras' },
+    ],
+    overview: {
+      description:
+        'Supervisa la captura diaria, valida cierres pendientes y sincroniza los módulos dependientes en tiempo real.',
+      stats: [
+        { value: '5', label: 'Turnos abiertos' },
+        { value: '2', label: 'Bloqueos activos' },
+        { value: '92%', label: 'Sincronización completada' },
+      ],
+    },
+    shortcuts: ['Revisar consumos pendientes', 'Descargar bitácoras', 'Configurar alertas'],
+  },
+};
+
+const domainEntries: { id: DomainKey; label: string }[] = [
+  { id: 'configuracion', label: 'Configuración' },
+  { id: 'operacion', label: 'Operación diaria' },
+];
+
+function SidebarIcon({ name }: { name: SidebarIconName }) {
   switch (name) {
     case 'dashboard':
       return (
@@ -86,6 +179,51 @@ function SidebarIcon({ name }: { name: 'dashboard' | 'sliders' | 'factory' | 'us
           />
         </svg>
       );
+    case 'consumos':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2c-1.657 0-3 1.79-3 4v1H7a3 3 0 0 0-3 3v2h16V10a3 3 0 0 0-3-3h-2V6c0-2.21-1.343-4-3-4zm-8 12v4a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-4H4z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'producciones':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M4 4h4l2 3h4l2-3h4v6h-4l-2 3h-4l-2-3H4zM4 18h16v2H4z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'litros':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2 7 9c0 3.314 2.239 6 5 6s5-2.686 5-6l-5-7zm0 20a5 5 0 0 1-5-5h2a3 3 0 0 0 6 0h2a5 5 0 0 1-5 5z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'perdidas':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2 3 22h18L12 2zm0 4 6.16 14H5.84L12 6zm-1 5v5h2v-5h-2zm0 6v2h2v-2h-2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'sobrantes':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M4 4h16v10H5.414L4 15.414V4zm6 14h10v2H10v-2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
     default:
       return null;
   }
@@ -96,6 +234,30 @@ function App() {
   const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
   const [openSections, setOpenSections] = useState({ overview: true, shortcuts: false });
+  const [activeDomain, setActiveDomain] = useState<DomainKey>('configuracion');
+  const [operacionModulo, setOperacionModulo] = useState<OperacionModulo>('consumos');
+
+  const operacionRoutes = useMemo(() => buildOperacionRoutes(), []);
+  const navigationItems = useMemo<EnhancedNavItem[]>(() => {
+    if (activeDomain === 'operacion') {
+      return operacionRoutes.map((route) => ({
+        id: route.id,
+        label: route.title,
+        description: route.description,
+        icon: <SidebarIcon name={route.id} />,
+        onSelect: () => {
+          setOperacionModulo(route.id);
+          if (isCompactViewport) {
+            setIsSidebarVisible(false);
+          }
+        },
+        isActive: route.id === operacionModulo,
+      }));
+    }
+    return buildConfiguracionNavigation();
+  }, [activeDomain, operacionRoutes, operacionModulo, isCompactViewport, setIsSidebarVisible]);
+
+  const domainConfig = domainConfigs[activeDomain];
 
   useEffect(() => {
     const handleResize = () => {
@@ -109,8 +271,6 @@ function App() {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
-
-  const navigationItems = useMemo(() => buildNavigation(), []);
 
   const toggleSidebar = () => {
     if (isCompactViewport) {
@@ -172,22 +332,43 @@ function App() {
 
             <div className="app-navbar__brand">
               <div className="app-navbar__logo" aria-hidden="true">
-                🌿
+                {domainConfig.logo}
               </div>
               <div className="app-navbar__headline">
-                <p className="app-navbar__eyebrow">Suite Herbal ERP</p>
-                <h1 className="app-navbar__title">Configuración y catálogos</h1>
-                <p className="app-navbar__subtitle">
-                  Administra los catálogos maestros y parámetros generales utilizados por los módulos operativos.
-                </p>
+                <p className="app-navbar__eyebrow">{domainConfig.eyebrow}</p>
+                <h1 className="app-navbar__title">{domainConfig.title}</h1>
+                <p className="app-navbar__subtitle">{domainConfig.subtitle}</p>
+                <div className="app-navbar__domains" role="tablist" aria-label="Dominios principales">
+                  {domainEntries.map((entry) => {
+                    const isActive = entry.id === activeDomain;
+                    return (
+                      <button
+                        key={entry.id}
+                        type="button"
+                        role="tab"
+                        className="app-navbar__domain-button"
+                        aria-selected={isActive}
+                        data-active={isActive}
+                        onClick={() => setActiveDomain(entry.id)}
+                      >
+                        {entry.label}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           </div>
           <div className="app-navbar__actions" aria-label="Acciones rápidas">
-            <button type="button" className="app-navbar__action app-navbar__action--primary">
-              Agregar catálogo
-            </button>
-            <button type="button" className="app-navbar__action">Centro de ayuda</button>
+            {domainConfig.actions.map((action) => (
+              <button
+                key={action.label}
+                type="button"
+                className={`app-navbar__action${action.variant === 'primary' ? ' app-navbar__action--primary' : ''}`}
+              >
+                {action.label}
+              </button>
+            ))}
           </div>
         </div>
       </header>
@@ -235,6 +416,10 @@ function App() {
                         className="app-sidebar__nav-item"
                         aria-label={item.label}
                         tabIndex={0}
+                        onClick={item.onSelect}
+                        data-active={item.isActive ?? false}
+                        aria-pressed={item.isActive ?? undefined}
+                        aria-current={item.isActive ? 'page' : undefined}
                       >
                         <span className="app-sidebar__nav-icon" aria-hidden="true">
                           {item.icon}
@@ -260,23 +445,14 @@ function App() {
                   <span aria-hidden="true">{openSections.overview ? '−' : '+'}</span>
                 </button>
                 <div className="app-sidebar__section-body" hidden={!openSections.overview}>
-                  <p className="app-sidebar__description">
-                    Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de
-                    publicar cambios.
-                  </p>
+                  <p className="app-sidebar__description">{domainConfig.overview.description}</p>
                   <ul className="app-sidebar__stats">
-                    <li className="app-sidebar__stat">
-                      <span className="app-sidebar__stat-value">4</span>
-                      <span className="app-sidebar__stat-label">Catálogos activos</span>
-                    </li>
-                    <li className="app-sidebar__stat">
-                      <span className="app-sidebar__stat-value">3</span>
-                      <span className="app-sidebar__stat-label">Dependencias críticas</span>
-                    </li>
-                    <li className="app-sidebar__stat">
-                      <span className="app-sidebar__stat-value">En línea</span>
-                      <span className="app-sidebar__stat-label">Estado de sincronización</span>
-                    </li>
+                    {domainConfig.overview.stats.map((stat) => (
+                      <li key={stat.label} className="app-sidebar__stat">
+                        <span className="app-sidebar__stat-value">{stat.value}</span>
+                        <span className="app-sidebar__stat-label">{stat.label}</span>
+                      </li>
+                    ))}
                   </ul>
                 </div>
               </section>
@@ -293,21 +469,13 @@ function App() {
                 </button>
                 <div className="app-sidebar__section-body" hidden={!openSections.shortcuts}>
                   <ul className="app-sidebar__links">
-                    <li>
-                      <button type="button" className="app-sidebar__link">
-                        Revisar dependencias
-                      </button>
-                    </li>
-                    <li>
-                      <button type="button" className="app-sidebar__link">
-                        Programar sincronización
-                      </button>
-                    </li>
-                    <li>
-                      <button type="button" className="app-sidebar__link">
-                        Descargar respaldo
-                      </button>
-                    </li>
+                    {domainConfig.shortcuts.map((shortcut) => (
+                      <li key={shortcut}>
+                        <button type="button" className="app-sidebar__link">
+                          {shortcut}
+                        </button>
+                      </li>
+                    ))}
                   </ul>
                 </div>
               </section>
@@ -315,7 +483,11 @@ function App() {
           </aside>
 
           <main className="app-main">
-            <ConfiguracionModule />
+            {activeDomain === 'configuracion' ? (
+              <ConfiguracionModule />
+            ) : (
+              <OperacionModule initialModulo={operacionModulo} />
+            )}
           </main>
         </div>
       </div>

--- a/frontend-app/src/modules/operacion/context/OperacionContext.tsx
+++ b/frontend-app/src/modules/operacion/context/OperacionContext.tsx
@@ -81,6 +81,12 @@ export const OperacionProvider: React.FC<OperacionProviderProps> = ({ initialMod
   const [vistas, setVistas] = useState<VistaGuardada[]>(() => getLocalStorageItem(VIEWS_KEY, []));
 
   useEffect(() => {
+    if (initialModulo && initialModulo !== modulo) {
+      setModulo(initialModulo);
+    }
+  }, [initialModulo, modulo, setModulo]);
+
+  useEffect(() => {
     setFiltros(getLocalStorageItem(`operacion:${modulo}:filters`, getDefaultFilters(modulo)));
   }, [modulo]);
 

--- a/frontend-app/src/modules/operacion/index.tsx
+++ b/frontend-app/src/modules/operacion/index.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { OperacionProvider } from './context/OperacionContext';
 import OperacionLayout from './components/OperacionLayout';
+import type { OperacionModulo } from './types';
 
-const OperacionModule: React.FC = () => (
-  <OperacionProvider>
+interface OperacionModuleProps {
+  initialModulo?: OperacionModulo;
+}
+
+const OperacionModule: React.FC<OperacionModuleProps> = ({ initialModulo }) => (
+  <OperacionProvider initialModulo={initialModulo}>
     <OperacionLayout />
   </OperacionProvider>
 );

--- a/frontend-app/src/modules/operacion/routes.tsx
+++ b/frontend-app/src/modules/operacion/routes.tsx
@@ -19,7 +19,7 @@ export function buildOperacionRoutes(): OperacionRoute[] {
       title: 'Consumos',
       description: 'Captura y valida consumos diarios según documentación funcional.',
       permissions: ['operacion.consumos'],
-      element: <OperacionModule />,
+      element: <OperacionModule initialModulo="consumos" />,
     },
     {
       id: 'producciones',
@@ -27,7 +27,7 @@ export function buildOperacionRoutes(): OperacionRoute[] {
       title: 'Producciones',
       description: 'Gestiona órdenes de producción y sincronización con existencias.',
       permissions: ['operacion.producciones'],
-      element: <OperacionModule />,
+      element: <OperacionModule initialModulo="producciones" />,
     },
     {
       id: 'litros',
@@ -35,7 +35,7 @@ export function buildOperacionRoutes(): OperacionRoute[] {
       title: 'Litros de crema',
       description: 'Monitoreo de litros de crema por lote y turno.',
       permissions: ['operacion.litros'],
-      element: <OperacionModule />,
+      element: <OperacionModule initialModulo="litros" />,
     },
     {
       id: 'perdidas',
@@ -43,7 +43,7 @@ export function buildOperacionRoutes(): OperacionRoute[] {
       title: 'Pérdidas',
       description: 'Registro y auditoría de pérdidas y mermas.',
       permissions: ['operacion.perdidas'],
-      element: <OperacionModule />,
+      element: <OperacionModule initialModulo="perdidas" />,
     },
     {
       id: 'sobrantes',
@@ -51,7 +51,7 @@ export function buildOperacionRoutes(): OperacionRoute[] {
       title: 'Sobrantes',
       description: 'Control de sobrantes y destino final.',
       permissions: ['operacion.sobrantes'],
-      element: <OperacionModule />,
+      element: <OperacionModule initialModulo="sobrantes" />,
     },
   ];
 }


### PR DESCRIPTION
## Summary
- add a domain selector in the main shell so users can switch between Configuración and Operación diaria with contextual copy and actions
- highlight operación routes in the sidebar and render the Operación layout when selected, keeping module state in sync
- allow the operación provider and routes to receive an initial módulo so deep links activate the corresponding view

## Testing
- npm run build *(fails: missing dev dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e568327c408330a46e625607e1df20