### PR TITLE
Improve paso 05 operation SPA UX and data resiliency

### DIFF
--- a/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
@@ -81,7 +81,14 @@ const OperacionLayout: React.FC = () => {
       </header>
       <ResumenContextualSection resumen={resumen} totalRegistros={totalRegistros} lastEvent={lastEvent} />
       <OperacionFilterBar config={config} />
-      <OperacionDataGrid config={config} registros={query.data ?? []} onSelect={setSelected} />
+      <OperacionDataGrid
+        config={config}
+        registros={query.data ?? []}
+        onSelect={setSelected}
+        loading={query.status === 'loading'}
+        error={query.error}
+        onRetry={query.refetch}
+      />
       <MassActionsDrawer
         selected={selected}
         onRun={handleAccion}

--- a/frontend-app/src/modules/operacion/operacion.css
+++ b/frontend-app/src/modules/operacion/operacion.css
@@ -61,6 +61,24 @@
   cursor: pointer;
 }
 
+.operacion-filtros .saved-views {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  grid-column: 1 / -1;
+}
+
+.operacion-filtros .saved-views select {
+  min-width: 200px;
+  flex: 1 1 220px;
+}
+
+.operacion-filtros .saved-views button {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .operacion-datagrid {
   background: #fff;
   border-radius: 12px;
@@ -68,6 +86,47 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+.operacion-datagrid--placeholder {
+  justify-content: center;
+  align-items: center;
+  min-height: 220px;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.operacion-datagrid--placeholder p {
+  margin: 0;
+  color: #475569;
+}
+
+.operacion-datagrid--placeholder button {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+.operacion-datagrid--placeholder small {
+  color: #64748b;
+}
+
+.operacion-datagrid--placeholder .spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid #cbd5f5;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .operacion-datagrid table {


### PR DESCRIPTION
## Summary
- adjust the saved views layout and add placeholder styles so the paso 05 toolbar no longer clips buttons
- harden the query client and record extraction utilities to consume varied API responses reliably
- surface loading, error, and empty states in the operación diaria grid while wiring the layout to pass query status

## Testing
- npm run build *(fails: missing `vite/client` and `node` type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e583ae2280833091e0b5be2aaa3842