### PR TITLE
Oculta acciones masivas y paneles de importación tras botones

### DIFF
--- a/frontend-app/src/modules/operacion/components/BulkUploadDialog.tsx
+++ b/frontend-app/src/modules/operacion/components/BulkUploadDialog.tsx
@@ -16,9 +16,10 @@ interface Props {
     | { success: true; registros: OperacionRegistro[] }
     | { success: false; errores: unknown }
   >;
+  onClose?: () => void;
 }
 
-const BulkUploadDialog: React.FC<Props> = ({ modulo, schema, status, bitacora, onImport }) => {
+const BulkUploadDialog: React.FC<Props> = ({ modulo, schema, status, bitacora, onImport, onClose }) => {
   const [rawInput, setRawInput] = useState('');
   const [usuario, setUsuario] = useState('analista.01');
   const [mensaje, setMensaje] = useState<string | null>(null);
@@ -56,9 +57,21 @@ const BulkUploadDialog: React.FC<Props> = ({ modulo, schema, status, bitacora, o
 
   return (
     <section aria-label="Carga masiva" className="progress-panel">
-      <header>
-        <strong>Carga masiva para {modulo}</strong>
-        <p>Los esquemas validan campos clave descritos en la documentación de importaciones.</p>
+      <header className="operacion-panel-header">
+        <div>
+          <strong>Carga masiva para {modulo}</strong>
+          <p>Los esquemas validan campos clave descritos en la documentación de importaciones.</p>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            className="operacion-panel-close"
+            onClick={onClose}
+            aria-label="Cerrar carga masiva"
+          >
+            ×
+          </button>
+        )}
       </header>
       <label>
         Usuario responsable

--- a/frontend-app/src/modules/operacion/components/MassActionsDrawer.tsx
+++ b/frontend-app/src/modules/operacion/components/MassActionsDrawer.tsx
@@ -6,14 +6,33 @@ interface Props {
   onRun: (accion: 'aprobar' | 'recalcular' | 'cerrar') => void;
   ultimoResultado?: AccionMasivaResultado;
   isProcessing?: boolean;
+  onClose?: () => void;
 }
 
-const MassActionsDrawer: React.FC<Props> = ({ selected, onRun, ultimoResultado, isProcessing = false }) => {
+const MassActionsDrawer: React.FC<Props> = ({
+  selected,
+  onRun,
+  ultimoResultado,
+  isProcessing = false,
+  onClose,
+}) => {
   const disabled = selected.length === 0 || isProcessing;
 
   return (
     <aside className="operacion-mass-actions">
-      <h4>Acciones masivas</h4>
+      <div className="operacion-panel-header">
+        <h4>Acciones masivas</h4>
+        {onClose && (
+          <button
+            type="button"
+            className="operacion-panel-close"
+            onClick={onClose}
+            aria-label="Cerrar acciones masivas"
+          >
+            ×
+          </button>
+        )}
+      </div>
       <p>{selected.length} registros seleccionados</p>
       {isProcessing && <p>Ejecutando acción…</p>}
       <div>

--- a/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
@@ -34,6 +34,9 @@ const OperacionLayout: React.FC = () => {
   const [selected, setSelected] = useState<string[]>([]);
   const [resultado, setResultado] = useState<AccionMasivaResultado | undefined>();
   const [accionEnProgreso, setAccionEnProgreso] = useState(false);
+  const [showMassActions, setShowMassActions] = useState(false);
+  const [showBulkUpload, setShowBulkUpload] = useState(false);
+  const [showProgress, setShowProgress] = useState(false);
 
   useEffect(() => {
     if (!query.data || query.data.length === 0) return;
@@ -70,6 +73,9 @@ const OperacionLayout: React.FC = () => {
   };
 
   const totalRegistros = useMemo(() => query.data?.length ?? 0, [query.data]);
+  const massPanelId = 'operacion-mass-actions-panel';
+  const bulkPanelId = 'operacion-bulk-upload-panel';
+  const progressPanelId = 'operacion-progress-panel';
 
   return (
     <div className="operacion-module">
@@ -82,23 +88,72 @@ const OperacionLayout: React.FC = () => {
       <ResumenContextualSection resumen={resumen} totalRegistros={totalRegistros} lastEvent={lastEvent} />
       <OperacionFilterBar config={config} />
       <OperacionDataGrid config={config} registros={query.data ?? []} onSelect={setSelected} />
-      <MassActionsDrawer
-        selected={selected}
-        onRun={handleAccion}
-        ultimoResultado={resultado}
-        isProcessing={accionEnProgreso}
-      />
+      {showMassActions && (
+        <div id={massPanelId}>
+          <MassActionsDrawer
+            selected={selected}
+            onRun={handleAccion}
+            ultimoResultado={resultado}
+            isProcessing={accionEnProgreso}
+            onClose={() => setShowMassActions(false)}
+          />
+        </div>
+      )}
       <div className="operacion-toolbar">
         <div>
           <strong>Resumen</strong>
           <p>{resumenTabla.totalRegistros} registros · Estado: {query.status}</p>
         </div>
+        <div className="operacion-actions">
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setShowMassActions((value) => !value)}
+            aria-expanded={showMassActions}
+            aria-controls={massPanelId}
+          >
+            Acciones masivas
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setShowBulkUpload((value) => !value)}
+            aria-expanded={showBulkUpload}
+            aria-controls={bulkPanelId}
+          >
+            Carga masiva
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setShowProgress((value) => !value)}
+            aria-expanded={showProgress}
+            aria-controls={progressPanelId}
+          >
+            Importación masiva
+          </button>
+        </div>
         <button type="button" onClick={reset}>
           Reiniciar importación
         </button>
       </div>
-      <BulkUploadDialog modulo={modulo} schema={schema} status={status} bitacora={bitacora} onImport={importar} />
-      <ProgressPanel status={status} bitacora={bitacora} />
+      {showBulkUpload && (
+        <div id={bulkPanelId}>
+          <BulkUploadDialog
+            modulo={modulo}
+            schema={schema}
+            status={status}
+            bitacora={bitacora}
+            onImport={importar}
+            onClose={() => setShowBulkUpload(false)}
+          />
+        </div>
+      )}
+      {showProgress && (
+        <div id={progressPanelId}>
+          <ProgressPanel status={status} bitacora={bitacora} onClose={() => setShowProgress(false)} />
+        </div>
+      )}
       <ImportErrorLog bitacora={bitacora} />
     </div>
   );

--- a/frontend-app/src/modules/operacion/components/ProgressPanel.tsx
+++ b/frontend-app/src/modules/operacion/components/ProgressPanel.tsx
@@ -4,6 +4,7 @@ import type { BitacoraImportacion, ImportStatus } from '../types';
 interface Props {
   status: ImportStatus;
   bitacora: BitacoraImportacion | null;
+  onClose?: () => void;
 }
 
 const statusLabel: Record<ImportStatus, string> = {
@@ -14,14 +15,26 @@ const statusLabel: Record<ImportStatus, string> = {
   failed: 'Con errores',
 };
 
-const ProgressPanel: React.FC<Props> = ({ status, bitacora }) => {
+const ProgressPanel: React.FC<Props> = ({ status, bitacora, onClose }) => {
   const porcentaje = bitacora ? (bitacora.resumen.exitosos / bitacora.resumen.total) * 100 : 0;
 
   return (
     <div className="progress-panel" aria-live="polite">
-      <header>
-        <strong>Importación masiva</strong>
-        <div>Estado actual: {statusLabel[status]}</div>
+      <header className="operacion-panel-header">
+        <div>
+          <strong>Importación masiva</strong>
+          <div>Estado actual: {statusLabel[status]}</div>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            className="operacion-panel-close"
+            onClick={onClose}
+            aria-label="Cerrar importación masiva"
+          >
+            ×
+          </button>
+        )}
       </header>
       <div className="bar" role="progressbar" aria-valuenow={porcentaje} aria-valuemin={0} aria-valuemax={100}>
         <div className="bar-inner" style={{ width: `${porcentaje}%` }} />

--- a/frontend-app/src/modules/operacion/operacion.css
+++ b/frontend-app/src/modules/operacion/operacion.css
@@ -119,6 +119,13 @@
   color: #2563eb;
 }
 
+.operacion-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .operacion-chip {
   display: inline-flex;
   align-items: center;
@@ -155,6 +162,7 @@
   display: grid;
   gap: 0.75rem;
   background: #f8fafc;
+  border-radius: 12px;
 }
 
 .operacion-mass-actions h4 {
@@ -198,6 +206,27 @@
   border-radius: 10px;
   padding: 1rem;
   box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.operacion-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.operacion-panel-close {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #475569;
+}
+
+.operacion-panel-close:hover,
+.operacion-panel-close:focus-visible {
+  color: #0f172a;
 }
 
 .progress-panel .bar {


### PR DESCRIPTION
## Summary
- oculta los paneles de acciones masivas, carga e importación masiva hasta que el usuario los despliegue desde la barra de herramientas
- agrega controles de cierre y cabeceras consistentes a los paneles emergentes para facilitar su comprensión

## Testing
- npm run lint *(falla: dependencias de eslint no disponibles en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68e58434fff483308963ad99932bf5d0