### PR TITLE
Fix hook order in OperacionDataGrid to prevent crash

### DIFF
--- a/frontend-app/src/modules/operacion/components/OperacionDataGrid.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionDataGrid.tsx
@@ -19,6 +19,11 @@ const OperacionDataGrid: React.FC<Props> = ({ config, registros, onSelect, loadi
 
   const agrupacion = config.agrupaciones?.[0];
 
+  const datos = useMemo(() => {
+    if (!agrupacion) return [{ key: 'all', registros }];
+    return groupBy(registros, agrupacion);
+  }, [registros, agrupacion]);
+
   useEffect(() => {
     setVisibleRows(50);
   }, [registros]);
@@ -69,12 +74,6 @@ const OperacionDataGrid: React.FC<Props> = ({ config, registros, onSelect, loadi
       </div>
     );
   }
-
-  const datos = useMemo(() => {
-    if (!agrupacion) return [{ key: 'all', registros }];
-    return groupBy(registros, agrupacion);
-  }, [registros, agrupacion]);
-
   const renderCell = (registro: OperacionRegistro, key: string) => {
     const value = (registro as Record<string, unknown>)[key];
     if (typeof value === 'number') {


### PR DESCRIPTION
## Summary
- ensure OperacionDataGrid always calls the memoized grouping helper so hooks run in a consistent order

## Testing
- npm run lint *(fails: Missing dependency @eslint/js in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e59d1f0574833099d6bc056e8952ef