### PR TITLE
feat: add pagination to operación data grid

### DIFF
--- a/frontend-app/src/modules/operacion/operacion.css
+++ b/frontend-app/src/modules/operacion/operacion.css
@@ -178,6 +178,69 @@
   color: #2563eb;
 }
 
+.operacion-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.operacion-pagination__info {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.operacion-pagination__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.operacion-pagination__page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.operacion-pagination__page-size select {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.3rem 0.5rem;
+  background: #fff;
+  color: #0f172a;
+}
+
+.operacion-pagination__button {
+  border: 1px solid #2563eb;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.operacion-pagination__button:disabled {
+  background: #cbd5f5;
+  border-color: #cbd5f5;
+  color: #64748b;
+  cursor: not-allowed;
+}
+
+.operacion-pagination__page {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
 .operacion-actions {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add client-side pagination controls to the operación data grid so large lists mirror configuraciones behaviour
- flatten grouped registros into paged slices while preserving selection handling and contextual styling
- style the new paginator with operación-specific classes that align with existing module aesthetics

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a119dcc883308384c61bb6322eee