### PR TITLE
Use configurated centers in costos filters

### DIFF
--- a/frontend-app/src/modules/costos/components/CostosFilterBar.tsx
+++ b/frontend-app/src/modules/costos/components/CostosFilterBar.tsx
@@ -1,17 +1,24 @@
 import React, { useMemo } from 'react';
+import { useCentros } from '../../configuracion/hooks/useCentros';
 import { useCostosContext } from '../context/CostosContext';
 import '../costos.css';
 
-const centrosEjemplo = [
-  { id: '101', nombre: 'Planta Principal' },
-  { id: '202', nombre: 'Centro de Apoyo' },
-  { id: '303', nombre: 'Planta Norte' },
-];
-
 const CostosFilterBar: React.FC = () => {
   const { submodule, filters, updateFilters, resetFilters } = useCostosContext();
+  const catalog = useCentros();
 
-  const centros = useMemo(() => centrosEjemplo, []);
+  const centros = useMemo(
+    () =>
+      [...catalog.items]
+        .map((centro) => ({
+          id: centro.id,
+          nombre: centro.nombre,
+          value: centro.nroCentro.toString(),
+          label: `${centro.nroCentro.toString().padStart(3, '0')} · ${centro.nombre}`.trim(),
+        }))
+        .sort((a, b) => Number(a.value) - Number(b.value)),
+    [catalog.items],
+  );
 
   return (
     <form
@@ -29,8 +36,8 @@ const CostosFilterBar: React.FC = () => {
         >
           <option value="">Todos</option>
           {centros.map((centro) => (
-            <option key={centro.id} value={centro.id}>
-              {centro.id} · {centro.nombre}
+            <option key={centro.id} value={centro.value}>
+              {centro.label}
             </option>
           ))}
         </select>

--- a/frontend-app/src/modules/costos/context/CostosContext.tsx
+++ b/frontend-app/src/modules/costos/context/CostosContext.tsx
@@ -27,16 +27,13 @@ const CostosContext = createContext<CostosContextValue | undefined>(undefined);
 const defaultFilters: Record<CostosSubModulo, CostosFilters> = {
   gastos: {
     calculationDate: new Date().toISOString().slice(0, 10),
-    centro: '101',
     esGastoDelPeriodo: true,
   },
   depreciaciones: {
     calculationDate: new Date().toISOString().slice(0, 10),
-    centro: '101',
   },
   sueldos: {
     calculationDate: new Date().toISOString().slice(0, 10),
-    centro: '101',
     nroEmpleado: null,
   },
   prorrateo: {


### PR DESCRIPTION
## Summary
- load available cost centers from the configuracion catalog inside the costos filter bar
- remove hardcoded center defaults so filters rely on the catalog data

## Testing
- npm run test *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68e6ea55483c8330b36922e137b58c50