### PR TITLE
feat: add importaciones module

### DIFF
--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 import ConfiguracionModule from './modules/configuracion';
 import OperacionModule from './modules/operacion';
 import CostosModule from './modules/costos';
+import ImportacionesModule from './modules/importaciones';
 import { buildOperacionRoutes } from './modules/operacion/routes';
 import { buildCostosRoutes } from './modules/costos/routes';
 import type { OperacionModulo } from './modules/operacion/types';
 import type { CostosSubModulo } from './modules/costos/types';
+import type { ImportacionesSection } from './modules/importaciones/types';
 import './App.css';
 
 type NavItem = {
@@ -14,7 +16,7 @@ type NavItem = {
   description: string;
   icon: JSX.Element;
 };
-type DomainKey = 'configuracion' | 'operacion' | 'costos';
+type DomainKey = 'configuracion' | 'operacion' | 'importaciones' | 'costos';
 
 type DomainAction = {
   label: string;
@@ -53,7 +55,24 @@ type SidebarIconName =
   | 'gastos'
   | 'depreciaciones'
   | 'sueldos'
-  | 'prorrateo';
+  | 'prorrateo'
+  | 'importar'
+  | 'bitacoras';
+
+const importacionesNavigation: { id: ImportacionesSection; label: string; description: string; icon: SidebarIconName }[] = [
+  {
+    id: 'importar',
+    label: 'Importar archivo MDB',
+    description: 'Carga archivos Access y distribuye la información entre módulos.',
+    icon: 'importar',
+  },
+  {
+    id: 'historial',
+    label: 'Historial de bitácoras',
+    description: 'Administra y audita las importaciones registradas.',
+    icon: 'bitacoras',
+  },
+];
 
 type EnhancedNavItem = NavItem & {
   onSelect?: () => void;
@@ -156,11 +175,33 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     },
     shortcuts: ['Ver existencias', 'Ir a asientos', 'Descargar bitácora'],
   },
+  importaciones: {
+    eyebrow: 'Suite Herbal ERP · Importaciones',
+    title: 'Importación de bases Access',
+    subtitle:
+      'Carga archivos .mdb, monitorea el procesamiento por tabla y gestiona las bitácoras generadas automáticamente.',
+    logo: '📥',
+    actions: [
+      { label: 'Nueva importación', variant: 'primary' },
+      { label: 'Bitácoras recientes' },
+    ],
+    overview: {
+      description:
+        'Controla la trazabilidad de las importaciones, revisa los resultados por tabla y audita los movimientos generados.',
+      stats: [
+        { value: '3', label: 'Importaciones en revisión' },
+        { value: '12', label: 'Tablas importadas hoy' },
+        { value: 'Sin alertas', label: 'Estado del proceso' },
+      ],
+    },
+    shortcuts: ['Ver últimas bitácoras', 'Descargar log de auditoría', 'Configurar alertas'],
+  },
 };
 
 const domainEntries: { id: DomainKey; label: string }[] = [
   { id: 'configuracion', label: 'Configuración' },
   { id: 'operacion', label: 'Operación diaria' },
+  { id: 'importaciones', label: 'Importaciones MDB' },
   { id: 'costos', label: 'Costos y consolidaciones' },
 ];
 
@@ -289,6 +330,24 @@ function SidebarIcon({ name }: { name: SidebarIconName }) {
           />
         </svg>
       );
+    case 'importar':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2a3 3 0 0 1 3 3v6.586l1.293-1.293 1.414 1.414L12 16.414 6.293 11.707l1.414-1.414L9 11.586V5a3 3 0 0 1 3-3zm-7 14h2v4h10v-4h2v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'bitacoras':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M6 3a3 3 0 0 0-3 3v13h2.5l1 2H19a2 2 0 0 0 2-2V6a3 3 0 0 0-3-3H6zm0 2h12a1 1 0 0 1 1 1v13H8.5l-1-2H5V6a1 1 0 0 1 1-1zm2 3v2h8V8H8zm0 4v2h6v-2H8z"
+            fill="currentColor"
+          />
+        </svg>
+      );
     default:
       return null;
   }
@@ -302,6 +361,7 @@ function App() {
   const [activeDomain, setActiveDomain] = useState<DomainKey>('configuracion');
   const [operacionModulo, setOperacionModulo] = useState<OperacionModulo>('consumos');
   const [costosModulo, setCostosModulo] = useState<CostosSubModulo>('gastos');
+  const [importacionesSection, setImportacionesSection] = useState<ImportacionesSection>('importar');
 
   const operacionRoutes = useMemo(() => buildOperacionRoutes(), []);
   const costosRoutes = useMemo(() => buildCostosRoutes(), []);
@@ -336,6 +396,21 @@ function App() {
         isActive: route.id === costosModulo,
       }));
     }
+    if (activeDomain === 'importaciones') {
+      return importacionesNavigation.map((item) => ({
+        id: item.id,
+        label: item.label,
+        description: item.description,
+        icon: <SidebarIcon name={item.icon} />,
+        onSelect: () => {
+          setImportacionesSection(item.id);
+          if (isCompactViewport) {
+            setIsSidebarVisible(false);
+          }
+        },
+        isActive: item.id === importacionesSection,
+      }));
+    }
     return buildConfiguracionNavigation();
   }, [
     activeDomain,
@@ -343,6 +418,7 @@ function App() {
     operacionModulo,
     costosRoutes,
     costosModulo,
+    importacionesSection,
     isCompactViewport,
     setIsSidebarVisible,
   ]);
@@ -577,6 +653,11 @@ function App() {
               <ConfiguracionModule />
             ) : activeDomain === 'operacion' ? (
               <OperacionModule initialModulo={operacionModulo} />
+            ) : activeDomain === 'importaciones' ? (
+              <ImportacionesModule
+                activeSection={importacionesSection}
+                onSectionChange={setImportacionesSection}
+              />
             ) : (
               <CostosModule initialSubmodule={costosModulo} />
             )}

--- a/frontend-app/src/modules/importaciones/api.ts
+++ b/frontend-app/src/modules/importaciones/api.ts
@@ -1,0 +1,157 @@
+import type {
+  CreateImportLogPayload,
+  ImportLog,
+  ImportLogFilters,
+  ImportResponse,
+  TableResult,
+  UpdateImportLogPayload,
+} from './types';
+
+export class ImportacionesApiError extends Error {
+  status?: number;
+  payload?: unknown;
+
+  constructor(message: string, options?: { status?: number; payload?: unknown }) {
+    super(message);
+    this.name = 'ImportacionesApiError';
+    this.status = options?.status;
+    this.payload = options?.payload;
+  }
+}
+
+const rawBaseUrl = import.meta.env?.VITE_API_URL ?? 'http://localhost:3000';
+const baseUrl = rawBaseUrl.replace(/\/$/, '');
+
+async function parseJsonSafe(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return { raw: text };
+  }
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const payload = await parseJsonSafe(response);
+    throw new ImportacionesApiError('HTTP_ERROR', { status: response.status, payload });
+  }
+  const payload = await parseJsonSafe(response);
+  return payload as T;
+}
+
+async function requestJson<TResponse>(
+  path: string,
+  options: RequestInit = {},
+): Promise<TResponse> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+    ...options,
+  });
+
+  return handleResponse<TResponse>(response);
+}
+
+export async function uploadImport({
+  file,
+  fechaImportacion,
+}: {
+  file: File;
+  fechaImportacion: string;
+}): Promise<ImportResponse> {
+  const formData = new FormData();
+  formData.append('mdbFile', file);
+  formData.append('fechaImportacion', fechaImportacion);
+
+  const response = await fetch(`${baseUrl}/import`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  return handleResponse<ImportResponse>(response);
+}
+
+export async function listImportLogs(
+  filters: ImportLogFilters = {},
+  options: { signal?: AbortSignal } = {},
+): Promise<ImportLog[]> {
+  const params = new URLSearchParams();
+
+  if (filters.search) {
+    params.set('search', filters.search);
+  }
+  if (filters.startDate) {
+    params.set('startDate', filters.startDate);
+  }
+  if (filters.endDate) {
+    params.set('endDate', filters.endDate);
+  }
+  if (typeof filters.page === 'number') {
+    params.set('page', String(filters.page));
+  }
+  if (typeof filters.pageSize === 'number') {
+    params.set('pageSize', String(filters.pageSize));
+  }
+
+  const suffix = params.toString() ? `?${params.toString()}` : '';
+  return requestJson<ImportLog[]>(`/api/importaciones${suffix}`, {
+    signal: options.signal,
+  });
+}
+
+export async function getImportLog(id: string, options: { signal?: AbortSignal } = {}): Promise<ImportLog> {
+  return requestJson<ImportLog>(`/api/importaciones/${id}`, {
+    signal: options.signal,
+  });
+}
+
+export async function createImportLog(
+  payload: CreateImportLogPayload,
+  options: { signal?: AbortSignal } = {},
+): Promise<ImportLog> {
+  return requestJson<ImportLog>('/api/importaciones', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    signal: options.signal,
+  });
+}
+
+export async function updateImportLog(
+  id: string,
+  payload: UpdateImportLogPayload,
+  options: { signal?: AbortSignal } = {},
+): Promise<ImportLog> {
+  return requestJson<ImportLog>(`/api/importaciones/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+    signal: options.signal,
+  });
+}
+
+export async function deleteImportLog(
+  id: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<{ message: string }> {
+  return requestJson<{ message: string }>(`/api/importaciones/${id}`, {
+    method: 'DELETE',
+    signal: options.signal,
+  });
+}
+
+export function computeTotals(results: TableResult[]): { inserted: number; errors: number } {
+  return results.reduce(
+    (acc, result) => {
+      acc.inserted += Number.isFinite(result.inserted) ? result.inserted : 0;
+      if (result.error) {
+        acc.errors += 1;
+      }
+      return acc;
+    },
+    { inserted: 0, errors: 0 },
+  );
+}

--- a/frontend-app/src/modules/importaciones/importaciones.css
+++ b/frontend-app/src/modules/importaciones/importaciones.css
@@ -1,0 +1,501 @@
+.importaciones-module {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: #f5f7fb;
+  min-height: 100%;
+}
+
+.importaciones-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.importaciones-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.importaciones-card--progress {
+  min-height: 260px;
+}
+
+.importaciones-card--history {
+  padding: 1.5rem;
+  gap: 1.5rem;
+}
+
+.importaciones-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.importaciones-card__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  margin: 0 0 0.25rem 0;
+}
+
+.importaciones-card__title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #0f172a;
+}
+
+.importaciones-status {
+  align-self: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.importaciones-status--uploading,
+.importaciones-status--processing {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.importaciones-status--completed {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.importaciones-status--error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.importaciones-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.importaciones-dropzone {
+  position: relative;
+  border: 2px dashed #cbd5f5;
+  border-radius: 14px;
+  padding: 1.75rem;
+  text-align: center;
+  background: #f8fbff;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.importaciones-dropzone[data-has-file='true'] {
+  border-color: #2563eb;
+  background: #f1f5ff;
+}
+
+.importaciones-dropzone__input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.importaciones-dropzone__headline {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.importaciones-dropzone__help,
+.importaciones-dropzone__hint {
+  margin: 0.35rem 0 0 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.importaciones-dropzone__file {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.importaciones-form__fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.importaciones-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.importaciones-field input[type='date'] {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.95rem;
+}
+
+.importaciones-button {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  padding: 0.55rem 1.2rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.importaciones-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.18);
+}
+
+.importaciones-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.importaciones-button--ghost {
+  background: #e2e8f0;
+  color: #1f2937;
+  box-shadow: none;
+}
+
+.importaciones-button--ghost:hover {
+  transform: none;
+  background: #cbd5e1;
+}
+
+.importaciones-button--danger {
+  background: linear-gradient(135deg, #ef4444, #b91c1c);
+}
+
+.importaciones-alert {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.importaciones-alert--error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.importaciones-alert--success {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.importaciones-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.importaciones-progress__bar {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.importaciones-progress__indicator {
+  height: 100%;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  transition: width 0.3s ease;
+}
+
+.importaciones-progress__message {
+  margin: 0;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.importaciones-progress__totals {
+  margin: 0;
+  color: #475569;
+}
+
+.importaciones-results__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.importaciones-results__header h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.importaciones-results__header p {
+  margin: 0;
+  color: #475569;
+}
+
+.importaciones-results__table-wrapper {
+  max-height: 240px;
+  overflow: auto;
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.importaciones-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.importaciones-table thead {
+  background: #f8fafc;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.importaciones-table th,
+.importaciones-table td {
+  text-align: left;
+  padding: 0.65rem 0.8rem;
+  border-bottom: 1px solid #e2e8f0;
+  color: #1f2937;
+}
+
+.importaciones-table tbody tr:hover {
+  background: #f1f5f9;
+}
+
+.importaciones-table--selectable tbody tr {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.importaciones-table--selectable tbody tr[data-selected='true'] {
+  background: #e0f2fe;
+}
+
+.importaciones-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.importaciones-badge--success {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.importaciones-badge--error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.importaciones-history {
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+}
+
+.importaciones-history__list {
+  flex: 1 1 55%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.importaciones-history__detail {
+  flex: 1 1 45%;
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+  min-height: 320px;
+}
+
+.importaciones-history__filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.importaciones-history__filters input[type='search'],
+.importaciones-history__filters input[type='date'] {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+}
+
+.importaciones-history__table-wrapper {
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+  overflow: hidden;
+  background: #fff;
+}
+
+.importaciones-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.importaciones-detail__loading {
+  margin: 0;
+  color: #475569;
+}
+
+.importaciones-detail--empty {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  min-height: 280px;
+}
+
+.importaciones-detail--empty h3 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.importaciones-detail--empty p {
+  margin: 0.25rem 0 0 0;
+  color: #475569;
+}
+
+.importaciones-detail__form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.importaciones-detail__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.importaciones-detail__form input,
+.importaciones-detail__form textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+  resize: vertical;
+}
+
+.importaciones-detail__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.importaciones-detail__metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.importaciones-detail__metadata div {
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.75rem;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.importaciones-detail__metadata dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+}
+
+.importaciones-detail__metadata dd {
+  margin: 0.25rem 0 0 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.importaciones-detail__results h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.importaciones-detail__results ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (max-width: 1024px) {
+  .importaciones-history {
+    flex-direction: column;
+  }
+
+  .importaciones-history__detail {
+    min-height: unset;
+  }
+}
+
+@media (max-width: 640px) {
+  .importaciones-module {
+    padding: 1rem;
+  }
+
+  .importaciones-card {
+    padding: 1rem;
+  }
+
+  .importaciones-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .importaciones-form__fields {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .importaciones-history__filters {
+    grid-template-columns: 1fr;
+  }
+
+  .importaciones-button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/frontend-app/src/modules/importaciones/index.tsx
+++ b/frontend-app/src/modules/importaciones/index.tsx
@@ -1,0 +1,896 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ImportacionesApiError,
+  computeTotals,
+  createImportLog,
+  deleteImportLog,
+  getImportLog,
+  listImportLogs,
+  updateImportLog,
+  uploadImport,
+} from './api';
+import type { ImportacionesSection, ImportLog, ManualLogDraft, TableResult } from './types';
+import './importaciones.css';
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB sugeridos por política.
+
+const emptyManualDraft: ManualLogDraft = {
+  fileName: '',
+  importDate: '',
+  recordsProcessed: '',
+  durationMs: '',
+  errorMessages: '',
+  notes: '',
+};
+
+type UploadStatus = 'idle' | 'uploading' | 'processing' | 'completed' | 'error';
+
+interface ImportacionesModuleProps {
+  activeSection: ImportacionesSection;
+  onSectionChange?: (section: ImportacionesSection) => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) return '0 bytes';
+  if (bytes === 0) return '0 bytes';
+  const units = ['bytes', 'KB', 'MB', 'GB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+function formatDate(value?: string): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function formatIsoDate(value?: string): string {
+  if (!value) return '';
+  return value.slice(0, 10);
+}
+
+function formatDuration(durationMs?: number): string {
+  if (!durationMs || durationMs < 0) return '—';
+  const seconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+  return `${minutes}m ${remainingSeconds.toString().padStart(2, '0')}s`;
+}
+
+function stringifyErrorMessages(messages?: string[]): string {
+  if (!messages || messages.length === 0) {
+    return '';
+  }
+  return messages.join('\n');
+}
+
+function parseErrorMessages(text: string): string[] | undefined {
+  if (!text.trim()) {
+    return undefined;
+  }
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function getUploadStatusLabel(status: UploadStatus): string {
+  switch (status) {
+    case 'uploading':
+      return 'Analizando archivo';
+    case 'processing':
+      return 'Procesando tablas';
+    case 'completed':
+      return 'Importación completada';
+    case 'error':
+      return 'Error al procesar';
+    default:
+      return 'Listo para importar';
+  }
+}
+
+function validateDraft(draft: ManualLogDraft): string[] {
+  const errors: string[] = [];
+  if (!draft.fileName.trim()) {
+    errors.push('El nombre de archivo es requerido.');
+  }
+  if (!draft.importDate) {
+    errors.push('La fecha de importación es obligatoria.');
+  }
+  if (draft.recordsProcessed.trim() === '') {
+    errors.push('Ingresa la cantidad de registros procesados.');
+  } else if (!/^\d+$/.test(draft.recordsProcessed.trim())) {
+    errors.push('Los registros procesados deben ser un número entero.');
+  }
+  if (draft.durationMs && !/^\d+$/.test(draft.durationMs.trim())) {
+    errors.push('La duración debe ser un número entero en milisegundos.');
+  }
+  return errors;
+}
+
+const ImportacionesModule: React.FC<ImportacionesModuleProps> = ({ activeSection, onSectionChange }) => {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [importDate, setImportDate] = useState('');
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const [uploadStatus, setUploadStatus] = useState<UploadStatus>('idle');
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null);
+  const [results, setResults] = useState<TableResult[]>([]);
+  const [totalRecords, setTotalRecords] = useState<number | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [history, setHistory] = useState<ImportLog[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
+  const [selectedLog, setSelectedLog] = useState<ImportLog | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [detailSuccess, setDetailSuccess] = useState<string | null>(null);
+  const [isCreatingManual, setIsCreatingManual] = useState(false);
+  const [manualDraft, setManualDraft] = useState<ManualLogDraft>(emptyManualDraft);
+
+  const orderedResults = useMemo<TableResult[]>(() => {
+    return [...results].sort((a, b) => a.table.localeCompare(b.table));
+  }, [results]);
+
+  const totals = useMemo(() => computeTotals(results), [results]);
+
+  const sanitizedSearch = searchTerm.trim();
+
+  const fetchHistory = useCallback(
+    async (options: { signal?: AbortSignal; silent?: boolean } = {}) => {
+      if (!options.silent) {
+        setHistoryLoading(true);
+      }
+      setHistoryError(null);
+      try {
+        const data = await listImportLogs(
+          {
+            search: sanitizedSearch || undefined,
+            startDate: startDate || undefined,
+            endDate: endDate || undefined,
+          },
+          { signal: options.signal },
+        );
+        if (options.signal?.aborted) {
+          return;
+        }
+        setHistory(data);
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          return;
+        }
+        setHistoryError('No se pudo cargar el historial de importaciones.');
+      } finally {
+        if (!options.silent) {
+          setHistoryLoading(false);
+        }
+      }
+    },
+    [sanitizedSearch, startDate, endDate],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      fetchHistory({ signal: controller.signal });
+    }, 250);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [fetchHistory]);
+
+  useEffect(() => {
+    if (selectedLog) {
+      setManualDraft({
+        fileName: selectedLog.fileName ?? '',
+        importDate: formatIsoDate(selectedLog.importDate),
+        recordsProcessed: selectedLog.recordsProcessed?.toString() ?? '',
+        durationMs: selectedLog.durationMs?.toString() ?? '',
+        errorMessages: stringifyErrorMessages(selectedLog.errorMessages),
+        notes: selectedLog.notes ?? '',
+      });
+      setIsCreatingManual(false);
+    }
+  }, [selectedLog]);
+
+  const resetManualDraft = useCallback(() => {
+    setManualDraft(emptyManualDraft);
+    setDetailError(null);
+    setDetailSuccess(null);
+  }, []);
+
+  const handleFileSelection = useCallback((file: File | null) => {
+    setFormErrors([]);
+    setUploadMessage(null);
+    if (!file) {
+      setSelectedFile(null);
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith('.mdb')) {
+      setFormErrors(['Selecciona un archivo con extensión .mdb.']);
+      setSelectedFile(null);
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setFormErrors([`El archivo supera el tamaño máximo permitido (${formatBytes(MAX_FILE_SIZE)}).`]);
+      setSelectedFile(null);
+      return;
+    }
+
+    setSelectedFile(file);
+  }, []);
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    event.preventDefault();
+    if (event.dataTransfer.files && event.dataTransfer.files.length > 0) {
+      const [file] = event.dataTransfer.files;
+      handleFileSelection(file ?? null);
+      event.dataTransfer.clearData();
+    }
+  };
+
+  const handleFileInputChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const { files } = event.target;
+    if (files && files.length > 0) {
+      handleFileSelection(files[0]);
+    }
+  };
+
+  const handleImportSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    const errors: string[] = [];
+    setUploadMessage(null);
+
+    if (!selectedFile) {
+      errors.push('Selecciona un archivo Access (.mdb).');
+    }
+    if (!importDate) {
+      errors.push('Define la fecha de importación.');
+    }
+
+    if (errors.length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    setFormErrors([]);
+    setUploadStatus('uploading');
+    setUploadProgress(20);
+
+    try {
+      const response = await uploadImport({
+        file: selectedFile as File,
+        fechaImportacion: importDate,
+      });
+
+      setUploadStatus('processing');
+      setUploadProgress(70);
+
+      const payloadResults = Array.isArray(response.results) ? response.results : [];
+      setResults(payloadResults);
+      setTotalRecords(
+        typeof response.totalRecords === 'number' && Number.isFinite(response.totalRecords)
+          ? response.totalRecords
+          : null,
+      );
+
+      setUploadStatus('completed');
+      setUploadProgress(100);
+      setUploadMessage('Importación completada exitosamente.');
+      setSelectedFile(null);
+
+      fetchHistory({ silent: false });
+    } catch (error) {
+      setUploadStatus('error');
+      if (error instanceof ImportacionesApiError && error.status === 409) {
+        setUploadMessage('Ya se realizó una importación para la fecha seleccionada. Revisa el historial.');
+      } else {
+        setUploadMessage('No fue posible procesar la importación. Intenta nuevamente.');
+      }
+    }
+  };
+
+  const handleSelectLog = async (log: ImportLog) => {
+    setSelectedLogId(log._id);
+    setDetailError(null);
+    setDetailSuccess(null);
+    setIsCreatingManual(false);
+    setDetailLoading(true);
+    try {
+      const fetched = await getImportLog(log._id);
+      setSelectedLog(fetched);
+      onSectionChange?.('historial');
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') {
+        return;
+      }
+      setDetailError('No fue posible obtener el detalle de la bitácora.');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const handleCreateManual = () => {
+    setSelectedLogId(null);
+    setSelectedLog(null);
+    setIsCreatingManual(true);
+    resetManualDraft();
+    onSectionChange?.('historial');
+  };
+
+  const handleManualDraftChange = (field: keyof ManualLogDraft, value: string) => {
+    setManualDraft((current) => ({ ...current, [field]: value }));
+  };
+
+  const parseDraftPayload = (draft: ManualLogDraft) => {
+    const payload = {
+      fileName: draft.fileName.trim(),
+      importDate: draft.importDate,
+      recordsProcessed: Number.parseInt(draft.recordsProcessed.trim(), 10),
+      durationMs: draft.durationMs.trim() ? Number.parseInt(draft.durationMs.trim(), 10) : undefined,
+      errorMessages: parseErrorMessages(draft.errorMessages) ?? [],
+      notes: draft.notes.trim() ? draft.notes.trim() : undefined,
+    };
+    return payload;
+  };
+
+  const handleSubmitManual: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    setDetailError(null);
+    setDetailSuccess(null);
+
+    const validationErrors = validateDraft(manualDraft);
+    if (validationErrors.length > 0) {
+      setDetailError(validationErrors.join(' '));
+      return;
+    }
+
+    const payload = parseDraftPayload(manualDraft);
+
+    try {
+      setDetailLoading(true);
+      if (isCreatingManual) {
+        const created = await createImportLog(payload);
+        setDetailSuccess('Bitácora creada correctamente.');
+        setIsCreatingManual(false);
+        setSelectedLog(created);
+        setSelectedLogId(created._id);
+      } else if (selectedLog) {
+        const original = {
+          fileName: selectedLog.fileName,
+          importDate: formatIsoDate(selectedLog.importDate),
+          recordsProcessed: selectedLog.recordsProcessed,
+          durationMs: selectedLog.durationMs,
+          errorMessages: stringifyErrorMessages(selectedLog.errorMessages),
+          notes: selectedLog.notes ?? '',
+        };
+
+        const updates: Record<string, unknown> = {};
+
+        if (payload.fileName !== original.fileName) {
+          updates.fileName = payload.fileName;
+        }
+        if (payload.importDate !== original.importDate) {
+          updates.importDate = payload.importDate;
+        }
+        if (payload.recordsProcessed !== original.recordsProcessed) {
+          updates.recordsProcessed = payload.recordsProcessed;
+        }
+        if (payload.durationMs !== (original.durationMs ?? undefined)) {
+          updates.durationMs = payload.durationMs;
+        }
+        if (manualDraft.errorMessages.trim() !== original.errorMessages.trim()) {
+          updates.errorMessages = payload.errorMessages;
+        }
+        if ((payload.notes ?? '') !== original.notes.trim()) {
+          updates.notes = payload.notes;
+        }
+
+        if (Object.keys(updates).length === 0) {
+          setDetailError('Realiza un cambio antes de guardar la bitácora.');
+          return;
+        }
+
+        const updated = await updateImportLog(selectedLog._id, updates);
+        setSelectedLog(updated);
+        setDetailSuccess('Cambios guardados correctamente.');
+      }
+
+      fetchHistory({ silent: true });
+    } catch (error) {
+      if (error instanceof ImportacionesApiError && error.payload) {
+        setDetailError('El servidor rechazó la operación. Verifica la información.');
+      } else {
+        setDetailError('No fue posible guardar la bitácora.');
+      }
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const handleDeleteLog = async () => {
+    if (!selectedLog) return;
+
+    const confirmed = window.confirm(
+      `¿Seguro que deseas eliminar la bitácora "${selectedLog.fileName}" del ${formatIsoDate(selectedLog.importDate)}?`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      setDetailLoading(true);
+      await deleteImportLog(selectedLog._id);
+      setSelectedLog(null);
+      setSelectedLogId(null);
+      setIsCreatingManual(false);
+      resetManualDraft();
+      setDetailSuccess('Registro eliminado correctamente.');
+      fetchHistory({ silent: false });
+    } catch (error) {
+      setDetailError('No fue posible eliminar la bitácora.');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  return (
+    <div className="importaciones-module" data-section={activeSection}>
+      <div className="importaciones-grid">
+        <section className="importaciones-card">
+          <header className="importaciones-card__header">
+            <div>
+              <p className="importaciones-card__eyebrow">Carga de archivo MDB</p>
+              <h2 className="importaciones-card__title">Importar información</h2>
+            </div>
+            <span className={`importaciones-status importaciones-status--${uploadStatus}`}>
+              {getUploadStatusLabel(uploadStatus)}
+            </span>
+          </header>
+
+          <form className="importaciones-form" onSubmit={handleImportSubmit} noValidate>
+            <div
+              className="importaciones-dropzone"
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={handleDrop}
+              data-has-file={Boolean(selectedFile)}
+            >
+              <input
+                id="mdb-file"
+                type="file"
+                accept=".mdb"
+                onChange={handleFileInputChange}
+                className="importaciones-dropzone__input"
+              />
+              <div className="importaciones-dropzone__content">
+                <p className="importaciones-dropzone__headline">Arrastra y suelta el archivo .mdb aquí</p>
+                <p className="importaciones-dropzone__help">o haz clic para seleccionar desde tu dispositivo</p>
+                {selectedFile ? (
+                  <p className="importaciones-dropzone__file">{`${selectedFile.name} · ${formatBytes(selectedFile.size)}`}</p>
+                ) : (
+                  <p className="importaciones-dropzone__hint">Tamaño sugerido menor a {formatBytes(MAX_FILE_SIZE)}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="importaciones-form__fields">
+              <label className="importaciones-field">
+                <span>Fecha de importación</span>
+                <input
+                  type="date"
+                  value={importDate}
+                  onChange={(event) => setImportDate(event.target.value)}
+                  required
+                />
+              </label>
+
+              <button
+                type="submit"
+                className="importaciones-button"
+                disabled={uploadStatus === 'uploading' || uploadStatus === 'processing'}
+              >
+                Procesar archivo
+              </button>
+            </div>
+
+            {formErrors.length > 0 && (
+              <ul className="importaciones-alert importaciones-alert--error">
+                {formErrors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            )}
+
+            {uploadMessage && (
+              <p
+                className={`importaciones-alert ${uploadStatus === 'error' ? 'importaciones-alert--error' : 'importaciones-alert--success'}`}
+              >
+                {uploadMessage}
+              </p>
+            )}
+          </form>
+        </section>
+
+        <section className="importaciones-card importaciones-card--progress">
+          <header className="importaciones-card__header">
+            <div>
+              <p className="importaciones-card__eyebrow">Seguimiento</p>
+              <h2 className="importaciones-card__title">Estado del procesamiento</h2>
+            </div>
+          </header>
+
+          <div className="importaciones-progress">
+            <div className="importaciones-progress__bar" role="progressbar" aria-valuenow={uploadProgress} aria-valuemin={0} aria-valuemax={100}>
+              <div className="importaciones-progress__indicator" style={{ width: `${uploadProgress}%` }} />
+            </div>
+            <p className="importaciones-progress__message">{getUploadStatusLabel(uploadStatus)}</p>
+            {totalRecords !== null && (
+              <p className="importaciones-progress__totals">Total de registros procesados: {totalRecords}</p>
+            )}
+          </div>
+
+          {orderedResults.length > 0 && (
+            <div className="importaciones-results">
+              <header className="importaciones-results__header">
+                <h3>Resumen de tablas</h3>
+                <p>
+                  Insertados: <strong>{totals.inserted}</strong> · Tablas con errores: <strong>{totals.errors}</strong>
+                </p>
+              </header>
+              <div className="importaciones-results__table-wrapper">
+                <table className="importaciones-table">
+                  <thead>
+                    <tr>
+                      <th>Tabla Access</th>
+                      <th>Colección destino</th>
+                      <th>Insertados</th>
+                      <th>Error</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {orderedResults.map((result) => (
+                      <tr key={result.table}>
+                        <td>{result.table}</td>
+                        <td>{result.collection}</td>
+                        <td>{result.inserted}</td>
+                        <td>
+                          {result.error ? (
+                            <span className="importaciones-badge importaciones-badge--error">{result.error}</span>
+                          ) : (
+                            <span className="importaciones-badge importaciones-badge--success">Sin errores</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <section className="importaciones-card importaciones-card--history">
+        <header className="importaciones-card__header">
+          <div>
+            <p className="importaciones-card__eyebrow">Bitácoras</p>
+            <h2 className="importaciones-card__title">Historial de importaciones</h2>
+          </div>
+          <button type="button" className="importaciones-button" onClick={handleCreateManual}>
+            Nueva bitácora manual
+          </button>
+        </header>
+
+        <div className="importaciones-history">
+          <div className="importaciones-history__list">
+            <div className="importaciones-history__filters">
+              <input
+                type="search"
+                placeholder="Buscar por nombre de archivo"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+              />
+              <input
+                type="date"
+                value={startDate}
+                onChange={(event) => setStartDate(event.target.value)}
+                aria-label="Fecha inicial"
+              />
+              <input
+                type="date"
+                value={endDate}
+                onChange={(event) => setEndDate(event.target.value)}
+                aria-label="Fecha final"
+              />
+              <button
+                type="button"
+                className="importaciones-button importaciones-button--ghost"
+                onClick={() => {
+                  setSearchTerm('');
+                  setStartDate('');
+                  setEndDate('');
+                }}
+              >
+                Limpiar filtros
+              </button>
+            </div>
+
+            {historyError && <p className="importaciones-alert importaciones-alert--error">{historyError}</p>}
+
+            <div className="importaciones-history__table-wrapper">
+              <table className="importaciones-table importaciones-table--selectable">
+                <thead>
+                  <tr>
+                    <th>Archivo</th>
+                    <th>Fecha</th>
+                    <th>Procesados</th>
+                    <th>Duración</th>
+                    <th>Errores</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {historyLoading ? (
+                    <tr>
+                      <td colSpan={5}>Cargando historial…</td>
+                    </tr>
+                  ) : history.length === 0 ? (
+                    <tr>
+                      <td colSpan={5}>Sin registros disponibles para los filtros seleccionados.</td>
+                    </tr>
+                  ) : (
+                    history.map((log) => {
+                      const errorCount = log.totalErrors ?? log.errorMessages?.length ?? 0;
+                      return (
+                        <tr
+                          key={log._id}
+                          data-selected={selectedLogId === log._id}
+                          onClick={() => handleSelectLog(log)}
+                        >
+                          <td>{log.fileName}</td>
+                          <td>{formatDate(log.importDate)}</td>
+                          <td>{log.recordsProcessed}</td>
+                          <td>{formatDuration(log.durationMs)}</td>
+                          <td>{errorCount}</td>
+                        </tr>
+                      );
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <aside className="importaciones-history__detail" aria-live="polite">
+            {detailLoading && <p className="importaciones-detail__loading">Cargando detalle…</p>}
+
+            {!detailLoading && isCreatingManual && (
+              <div className="importaciones-detail">
+                <h3>Nueva bitácora manual</h3>
+                <p>Completa los campos para registrar una bitácora manual asociada a la importación.</p>
+                <form className="importaciones-detail__form" onSubmit={handleSubmitManual}>
+                  <label>
+                    <span>Nombre de archivo</span>
+                    <input
+                      type="text"
+                      value={manualDraft.fileName}
+                      onChange={(event) => handleManualDraftChange('fileName', event.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Fecha de importación</span>
+                    <input
+                      type="date"
+                      value={manualDraft.importDate}
+                      onChange={(event) => handleManualDraftChange('importDate', event.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Registros procesados</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={manualDraft.recordsProcessed}
+                      onChange={(event) => handleManualDraftChange('recordsProcessed', event.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Duración (ms)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={manualDraft.durationMs}
+                      onChange={(event) => handleManualDraftChange('durationMs', event.target.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Errores</span>
+                    <textarea
+                      rows={3}
+                      placeholder="Escribe un error por línea"
+                      value={manualDraft.errorMessages}
+                      onChange={(event) => handleManualDraftChange('errorMessages', event.target.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Notas</span>
+                    <textarea
+                      rows={3}
+                      value={manualDraft.notes}
+                      onChange={(event) => handleManualDraftChange('notes', event.target.value)}
+                    />
+                  </label>
+
+                  {detailError && <p className="importaciones-alert importaciones-alert--error">{detailError}</p>}
+                  {detailSuccess && <p className="importaciones-alert importaciones-alert--success">{detailSuccess}</p>}
+
+                  <div className="importaciones-detail__actions">
+                    <button type="submit" className="importaciones-button" disabled={detailLoading}>
+                      Guardar bitácora
+                    </button>
+                    <button
+                      type="button"
+                      className="importaciones-button importaciones-button--ghost"
+                      onClick={() => {
+                        setIsCreatingManual(false);
+                        resetManualDraft();
+                      }}
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                </form>
+              </div>
+            )}
+
+            {!detailLoading && !isCreatingManual && selectedLog && (
+              <div className="importaciones-detail">
+                <h3>Detalle de bitácora</h3>
+                <dl className="importaciones-detail__metadata">
+                  <div>
+                    <dt>Archivo</dt>
+                    <dd>{selectedLog.fileName}</dd>
+                  </div>
+                  <div>
+                    <dt>Fecha de importación</dt>
+                    <dd>{formatDate(selectedLog.importDate)}</dd>
+                  </div>
+                  <div>
+                    <dt>Registros procesados</dt>
+                    <dd>{selectedLog.recordsProcessed}</dd>
+                  </div>
+                  <div>
+                    <dt>Duración</dt>
+                    <dd>{formatDuration(selectedLog.durationMs)}</dd>
+                  </div>
+                  <div>
+                    <dt>Creado por</dt>
+                    <dd>{selectedLog.createdBy ?? 'Sistema'}</dd>
+                  </div>
+                  <div>
+                    <dt>Actualizado</dt>
+                    <dd>{selectedLog.updatedAt ? formatDate(selectedLog.updatedAt) : '—'}</dd>
+                  </div>
+                </dl>
+
+                <form className="importaciones-detail__form" onSubmit={handleSubmitManual}>
+                  <label>
+                    <span>Nombre de archivo</span>
+                    <input
+                      type="text"
+                      value={manualDraft.fileName}
+                      onChange={(event) => handleManualDraftChange('fileName', event.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Fecha de importación</span>
+                    <input
+                      type="date"
+                      value={manualDraft.importDate}
+                      onChange={(event) => handleManualDraftChange('importDate', event.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Registros procesados</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={manualDraft.recordsProcessed}
+                      onChange={(event) => handleManualDraftChange('recordsProcessed', event.target.value)}
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Duración (ms)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={manualDraft.durationMs}
+                      onChange={(event) => handleManualDraftChange('durationMs', event.target.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Errores</span>
+                    <textarea
+                      rows={3}
+                      placeholder="Escribe un error por línea"
+                      value={manualDraft.errorMessages}
+                      onChange={(event) => handleManualDraftChange('errorMessages', event.target.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Notas</span>
+                    <textarea
+                      rows={3}
+                      value={manualDraft.notes}
+                      onChange={(event) => handleManualDraftChange('notes', event.target.value)}
+                    />
+                  </label>
+
+                  {detailError && <p className="importaciones-alert importaciones-alert--error">{detailError}</p>}
+                  {detailSuccess && <p className="importaciones-alert importaciones-alert--success">{detailSuccess}</p>}
+
+                  <div className="importaciones-detail__actions">
+                    <button type="submit" className="importaciones-button" disabled={detailLoading}>
+                      Guardar cambios
+                    </button>
+                    <button
+                      type="button"
+                      className="importaciones-button importaciones-button--danger"
+                      onClick={handleDeleteLog}
+                      disabled={detailLoading}
+                    >
+                      Eliminar registro
+                    </button>
+                  </div>
+                </form>
+
+                {selectedLog.results && selectedLog.results.length > 0 && (
+                  <div className="importaciones-detail__results">
+                    <h4>Resultados asociados</h4>
+                    <ul>
+                      {selectedLog.results.map((result) => (
+                        <li key={result.table}>
+                          <strong>{result.table}</strong> → {result.collection} · {result.inserted} registros
+                          {result.error && <span className="importaciones-badge importaciones-badge--error">{result.error}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {!detailLoading && !isCreatingManual && !selectedLog && (
+              <div className="importaciones-detail importaciones-detail--empty">
+                <h3>Selecciona una bitácora</h3>
+                <p>Elige un elemento del listado para revisar su detalle o crea una nueva bitácora manual.</p>
+              </div>
+            )}
+          </aside>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ImportacionesModule;

--- a/frontend-app/src/modules/importaciones/types.ts
+++ b/frontend-app/src/modules/importaciones/types.ts
@@ -1,0 +1,60 @@
+export interface TableResult {
+  table: string;
+  collection: string;
+  inserted: number;
+  error?: string | null;
+}
+
+export interface ImportResponse {
+  totalRecords: number;
+  results: TableResult[];
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface ImportLog {
+  _id: string;
+  fileName: string;
+  importDate: string;
+  recordsProcessed: number;
+  durationMs?: number;
+  errorMessages?: string[];
+  createdAt?: string;
+  createdBy?: string;
+  updatedAt?: string;
+  updatedBy?: string;
+  notes?: string;
+  totalTables?: number;
+  totalErrors?: number;
+  results?: TableResult[];
+}
+
+export interface ImportLogFilters {
+  search?: string;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CreateImportLogPayload {
+  fileName: string;
+  importDate: string;
+  recordsProcessed: number;
+  durationMs?: number;
+  errorMessages?: string[];
+  notes?: string;
+}
+
+export type UpdateImportLogPayload = Partial<CreateImportLogPayload>;
+
+export interface ManualLogDraft {
+  fileName: string;
+  importDate: string;
+  recordsProcessed: string;
+  durationMs: string;
+  errorMessages: string;
+  notes: string;
+}
+
+export type ImportacionesSection = 'importar' | 'historial';


### PR DESCRIPTION
## Summary
- add an importaciones module with MDB upload, progress tracking, and import log management
- provide API utilities and types to interact with importación endpoints
- integrate the new module into the main navigation with tailored styling

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e6ed41e0948330bd60fc2de3135c43