### PR TITLE
Switch default currency to pesos

### DIFF
--- a/frontend-app/src/lib/formatters.ts
+++ b/frontend-app/src/lib/formatters.ts
@@ -6,7 +6,7 @@ export interface FormatCurrencyOptions {
 }
 
 export function formatCurrency(value: number, options: FormatCurrencyOptions = {}): string {
-  const { currency = 'USD', locale = 'es-MX', minimumFractionDigits = 2, maximumFractionDigits = 2 } = options;
+  const { currency = 'MXN', locale = 'es-MX', minimumFractionDigits = 2, maximumFractionDigits = 2 } = options;
   return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,

--- a/frontend-app/src/modules/costos/__tests__/transformers.test.ts
+++ b/frontend-app/src/modules/costos/__tests__/transformers.test.ts
@@ -51,7 +51,7 @@ test('calculateBalanceSummary calcula variación porcentual', () => {
     difference: 50,
     previousTotal: 800,
     warning: null,
-    currency: 'USD',
+    currency: 'MXN',
     history: [],
   };
 

--- a/frontend-app/src/modules/costos/api/costosApi.ts
+++ b/frontend-app/src/modules/costos/api/costosApi.ts
@@ -85,7 +85,7 @@ export async function fetchCostosList<K extends Exclude<CostosSubModulo, 'prorra
   let previousTotal: number | undefined;
   let totalAmount: number | undefined;
   let totalCount: number | undefined;
-  let currency = 'USD';
+  let currency = 'MXN';
   let history: { period: string; totalAmount: number }[] = [];
 
   if (Array.isArray(response)) {

--- a/frontend-app/src/modules/costos/utils/transformers.ts
+++ b/frontend-app/src/modules/costos/utils/transformers.ts
@@ -183,7 +183,7 @@ export function calculateBalanceSummary(
       balance: 0,
       variationPercentage: 0,
       warning: undefined,
-      currency: 'USD',
+      currency: 'MXN',
     };
   }
   const previous = response.previousTotal ?? 0;


### PR DESCRIPTION
## Summary
- default all currency formatting to MXN pesos
- align costos API and transformer defaults with peso currency values
- update unit tests to expect peso currency identifiers

## Testing
- npm test *(fails: TypeScript cannot find Node type definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ed9b8ce88330bded5644149fffc7