### PR TITLE
style: unify button styles across modules

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -33,6 +33,102 @@ body {
   color: var(--color-text-primary);
 }
 
+button {
+  font-family: var(--font-family-base);
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  border-radius: 12px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface-alt);
+  color: var(--color-text-primary);
+  padding: 10px 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  background: rgba(20, 94, 168, 0.08);
+  border-color: rgba(20, 94, 168, 0.3);
+  color: var(--color-primary-variant);
+  transform: translateY(-1px);
+}
+
+button:focus-visible {
+  outline: 2px solid rgba(20, 94, 168, 0.45);
+  outline-offset: 2px;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+button.primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+  box-shadow: 0 12px 24px rgba(20, 94, 168, 0.2);
+}
+
+button.primary:hover:not(:disabled) {
+  background: var(--color-primary-variant);
+  border-color: var(--color-primary-variant);
+  color: var(--color-on-primary);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--color-primary-variant);
+  border-color: rgba(20, 94, 168, 0.45);
+  box-shadow: none;
+}
+
+button.secondary:hover:not(:disabled) {
+  background: rgba(20, 94, 168, 0.1);
+  border-color: rgba(20, 94, 168, 0.55);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-color: var(--color-outline);
+  box-shadow: none;
+}
+
+button.ghost:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--color-text-primary);
+}
+
+button.danger {
+  background: var(--color-danger);
+  border-color: var(--color-danger);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(220, 38, 38, 0.22);
+}
+
+button.danger:hover:not(:disabled) {
+  background: var(--color-danger-hover);
+  border-color: var(--color-danger-hover);
+}
+
+button.pill {
+  border-radius: 999px;
+}
+
+button.small {
+  padding: 8px 12px;
+  font-size: 0.85rem;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/frontend-app/src/modules/configuracion/components/CatalogTable.tsx
+++ b/frontend-app/src/modules/configuracion/components/CatalogTable.tsx
@@ -113,7 +113,7 @@ const CatalogTable = <TEntity,>({
           </label>
           <button
             type="button"
-            className="config-pagination-button"
+            className="secondary small"
             onClick={() => setPage((current) => Math.max(1, current - 1))}
             disabled={page === 1}
           >
@@ -124,7 +124,7 @@ const CatalogTable = <TEntity,>({
           </span>
           <button
             type="button"
-            className="config-pagination-button"
+            className="secondary small"
             onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
             disabled={page === totalPages}
           >

--- a/frontend-app/src/modules/configuracion/components/ConfirmDialog.tsx
+++ b/frontend-app/src/modules/configuracion/components/ConfirmDialog.tsx
@@ -78,15 +78,10 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
           {description}
         </p>
         <div className="config-modal__actions">
-          <button
-            ref={cancelButtonRef}
-            type="button"
-            className="config-modal__button"
-            onClick={onCancel}
-          >
+          <button ref={cancelButtonRef} type="button" className="ghost" onClick={onCancel}>
             {cancelLabel}
           </button>
-          <button type="button" className="config-modal__button config-modal__button--danger" onClick={onConfirm}>
+          <button type="button" className="danger" onClick={onConfirm}>
             {confirmLabel}
           </button>
         </div>

--- a/frontend-app/src/modules/configuracion/components/FormActions.tsx
+++ b/frontend-app/src/modules/configuracion/components/FormActions.tsx
@@ -9,11 +9,11 @@ interface FormActionsProps {
 
 const FormActions: React.FC<FormActionsProps> = ({ onCancel, isSubmitting, submitLabel = 'Guardar' }) => (
   <div className="config-form-actions">
-    <button type="submit" className="config-button config-button--primary" disabled={isSubmitting}>
+    <button type="submit" className="primary" disabled={isSubmitting}>
       {submitLabel}
     </button>
     {onCancel && (
-      <button type="button" className="config-button config-button--ghost" onClick={onCancel}>
+      <button type="button" className="ghost" onClick={onCancel}>
         Cancelar
       </button>
     )}

--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -188,36 +188,6 @@ textarea.config-input {
   accent-color: var(--color-primary);
 }
 
-.config-button {
-  border-radius: 12px;
-  border: 1px solid transparent;
-  padding: 10px 18px;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.config-button--primary {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: var(--color-on-primary);
-}
-
-.config-button--primary:hover {
-  background: var(--color-primary-variant);
-}
-
-.config-button--ghost {
-  background: transparent;
-  border-color: var(--color-outline);
-  color: var(--color-primary-variant);
-}
-
-.config-button--ghost:hover {
-  background: rgba(20, 94, 168, 0.08);
-}
-
 .config-form-actions {
   display: flex;
   gap: 12px;
@@ -373,25 +343,6 @@ textarea.config-input {
   gap: 12px;
 }
 
-.config-pagination-button {
-  border: 1px solid var(--color-outline);
-  background: var(--color-surface-alt);
-  color: var(--color-text-primary);
-  border-radius: 10px;
-  padding: 8px 14px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.config-pagination-button:hover:not(:disabled) {
-  background: rgba(20, 94, 168, 0.08);
-}
-
-.config-pagination-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
 .config-table__pagination-page {
   font-size: 0.85rem;
   color: var(--color-text-secondary);
@@ -526,22 +477,14 @@ textarea.config-input {
 }
 
 .config-alert__action {
-  background: none;
-  border: none;
-  color: inherit;
-  font-weight: 600;
-  text-decoration: underline;
-  cursor: pointer;
-  padding: 0;
+  color: #991b1b;
+  border-color: rgba(220, 38, 38, 0.45);
 }
 
-.config-alert__action:hover {
-  opacity: 0.85;
-}
-
-.config-alert__action:focus-visible {
-  outline: 2px solid rgba(220, 38, 38, 0.55);
-  outline-offset: 2px;
+.config-alert__action:hover:not(:disabled) {
+  color: #7f1d1d;
+  border-color: rgba(185, 28, 28, 0.5);
+  background: rgba(254, 202, 202, 0.6);
 }
 
 .toast-viewport {
@@ -637,38 +580,6 @@ textarea.config-input {
   justify-content: flex-end;
   gap: 12px;
   margin-top: 12px;
-}
-
-.config-modal__button {
-  border-radius: 10px;
-  border: 1px solid var(--color-outline);
-  background: var(--color-surface);
-  padding: 8px 16px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.15s ease, border-color 0.2s ease;
-}
-
-.config-modal__button:hover {
-  background: rgba(20, 94, 168, 0.08);
-  border-color: var(--color-primary-variant);
-}
-
-.config-modal__button:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-.config-modal__button--danger {
-  background: rgba(220, 38, 38, 0.9);
-  border-color: rgba(185, 28, 28, 0.85);
-  color: #ffffff;
-}
-
-.config-modal__button--danger:hover {
-  background: var(--color-danger-hover);
-  transform: translateY(-1px);
 }
 
 @media (max-width: 900px) {

--- a/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
@@ -99,9 +99,7 @@ const ActividadesPage: React.FC = () => {
     setIsFormOpen(false);
   }, [form]);
 
-  const toggleButtonClassName = `config-button ${
-    isFormOpen ? 'config-button--ghost' : 'config-button--primary'
-  }`;
+  const toggleButtonClassName = isFormOpen ? 'ghost' : 'primary';
 
   const toggleButtonLabel = isFormOpen
     ? editingActividad
@@ -187,7 +185,7 @@ const ActividadesPage: React.FC = () => {
             {catalog.error && (
               <div className="config-alert" role="alert">
                 <span>No pudimos cargar las actividades. Intenta nuevamente.</span>
-                <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+                <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                   Reintentar
                 </button>
               </div>

--- a/frontend-app/src/modules/configuracion/pages/CentrosPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosPage.tsx
@@ -108,9 +108,7 @@ const CentrosPage: React.FC = () => {
     setIsFormOpen(false);
   }, [form]);
 
-  const toggleButtonClassName = `config-button ${
-    isFormOpen ? 'config-button--ghost' : 'config-button--primary'
-  }`;
+  const toggleButtonClassName = isFormOpen ? 'ghost' : 'primary';
 
   const toggleButtonLabel = isFormOpen
     ? editingCentro
@@ -196,7 +194,7 @@ const CentrosPage: React.FC = () => {
             {catalog.error && (
               <div className="config-alert" role="alert">
                 <span>No pudimos cargar los centros. Intenta nuevamente.</span>
-                <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+                <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                   Reintentar
                 </button>
               </div>

--- a/frontend-app/src/modules/configuracion/pages/EmpleadosPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/EmpleadosPage.tsx
@@ -99,9 +99,7 @@ const EmpleadosPage: React.FC = () => {
     setIsFormOpen(false);
   }, [form]);
 
-  const toggleButtonClassName = `config-button ${
-    isFormOpen ? 'config-button--ghost' : 'config-button--primary'
-  }`;
+  const toggleButtonClassName = isFormOpen ? 'ghost' : 'primary';
 
   const toggleButtonLabel = isFormOpen
     ? editingEmpleado
@@ -187,7 +185,7 @@ const EmpleadosPage: React.FC = () => {
             {catalog.error && (
               <div className="config-alert" role="alert">
                 <span>No pudimos cargar los empleados. Intenta nuevamente.</span>
-                <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+                <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                   Reintentar
                 </button>
               </div>

--- a/frontend-app/src/modules/configuracion/pages/ParametrosGeneralesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ParametrosGeneralesPage.tsx
@@ -221,7 +221,7 @@ const ParametrosGeneralesPage: React.FC = () => {
         {catalog.error && (
           <div className="config-alert" role="alert">
             <span>No pudimos cargar los parámetros. Intenta nuevamente.</span>
-            <button type="button" className="config-alert__action" onClick={() => catalog.refetch()}>
+            <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
               Reintentar
             </button>
           </div>

--- a/frontend-app/src/modules/costos/components/BalanceSummary.tsx
+++ b/frontend-app/src/modules/costos/components/BalanceSummary.tsx
@@ -27,7 +27,7 @@ const BalanceSummary: React.FC<BalanceSummaryProps> = ({ summary, formatted, onR
         </p>
       </div>
       {onRefresh && (
-        <button type="button" onClick={onRefresh} disabled={isLoading}>
+        <button type="button" className="secondary" onClick={onRefresh} disabled={isLoading}>
           {isLoading ? 'Actualizando…' : 'Actualizar'}
         </button>
       )}

--- a/frontend-app/src/modules/costos/components/CostosDataTable.tsx
+++ b/frontend-app/src/modules/costos/components/CostosDataTable.tsx
@@ -69,7 +69,7 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
     return (
       <div className="costos-empty-state" role="alert">
         <p>No se pudieron cargar los registros. Intenta nuevamente.</p>
-        <button type="button" onClick={onRetry}>
+        <button type="button" className="primary" onClick={onRetry}>
           Reintentar
         </button>
       </div>
@@ -93,7 +93,9 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
           <button
             key={action.id}
             type="button"
-            className={action.intent === 'primary' ? 'primary' : undefined}
+            className={
+              action.intent === 'primary' ? 'primary' : action.intent === 'secondary' ? 'secondary' : undefined
+            }
           >
             {action.label}
           </button>

--- a/frontend-app/src/modules/costos/components/CostosFilterBar.tsx
+++ b/frontend-app/src/modules/costos/components/CostosFilterBar.tsx
@@ -109,6 +109,7 @@ const CostosFilterBar: React.FC = () => {
         </button>
         <button
           type="button"
+          className="ghost"
           onClick={() => {
             resetFilters();
           }}

--- a/frontend-app/src/modules/costos/components/ProcessRunnerDialog.tsx
+++ b/frontend-app/src/modules/costos/components/ProcessRunnerDialog.tsx
@@ -62,7 +62,7 @@ const ProcessRunnerDialog: React.FC<ProcessRunnerDialogProps> = ({
           </div>
         </div>
         <div className="costos-dialog__footer">
-          <button type="button" onClick={onClose}>
+          <button type="button" className="ghost" onClick={onClose}>
             Cerrar
           </button>
           {process.status === 'idle' && (
@@ -71,7 +71,7 @@ const ProcessRunnerDialog: React.FC<ProcessRunnerDialogProps> = ({
             </button>
           )}
           {process.status === 'running' && (
-            <button type="button" onClick={onCancel}>
+            <button type="button" className="secondary" onClick={onCancel}>
               Cancelar
             </button>
           )}

--- a/frontend-app/src/modules/costos/costos.css
+++ b/frontend-app/src/modules/costos/costos.css
@@ -30,20 +30,7 @@
 }
 
 .costos-actions button {
-  border: 1px solid var(--color-outline);
-  border-radius: 10px;
-  padding: 10px 16px;
-  background: var(--color-surface-alt);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-weight: 600;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
-}
-
-.costos-actions button.primary {
-  background: var(--color-primary);
-  border-color: transparent;
-  color: #fff;
+  flex: 0 0 auto;
 }
 
 .costos-tabs {
@@ -341,10 +328,7 @@
 }
 
 .costos-dialog__footer button {
-  border-radius: 10px;
-  padding: 10px 16px;
-  font-weight: 600;
-  cursor: pointer;
+  flex: 0 0 auto;
 }
 
 .costos-progress-bar {

--- a/frontend-app/src/modules/operacion/components/BulkUploadDialog.tsx
+++ b/frontend-app/src/modules/operacion/components/BulkUploadDialog.tsx
@@ -86,7 +86,12 @@ const BulkUploadDialog: React.FC<Props> = ({ modulo, schema, status, bitacora, o
           placeholder='[ { "producto": "Mantequilla premium", ... } ]'
         />
       </label>
-      <button type="button" onClick={handleImport} disabled={!rawInput.trim() || status === 'processing'}>
+      <button
+        type="button"
+        className="primary"
+        onClick={handleImport}
+        disabled={!rawInput.trim() || status === 'processing'}
+      >
         Validar e importar
       </button>
       {mensaje && <p>{mensaje}</p>}

--- a/frontend-app/src/modules/operacion/components/ImportErrorLog.tsx
+++ b/frontend-app/src/modules/operacion/components/ImportErrorLog.tsx
@@ -34,10 +34,10 @@ const ImportErrorLog: React.FC<Props> = ({ bitacora }) => {
     <div className="import-error-log">
       <strong>Errores de importación</strong>
       <div>
-        <button type="button" onClick={() => descargar('csv')}>
+        <button type="button" className="secondary" onClick={() => descargar('csv')}>
           Descargar CSV
         </button>
-        <button type="button" onClick={() => descargar('json')}>
+        <button type="button" className="secondary" onClick={() => descargar('json')}>
           Descargar JSON
         </button>
       </div>

--- a/frontend-app/src/modules/operacion/components/MassActionsDrawer.tsx
+++ b/frontend-app/src/modules/operacion/components/MassActionsDrawer.tsx
@@ -36,13 +36,13 @@ const MassActionsDrawer: React.FC<Props> = ({
       <p>{selected.length} registros seleccionados</p>
       {isProcessing && <p>Ejecutando acción…</p>}
       <div>
-        <button type="button" onClick={() => onRun('aprobar')} disabled={disabled}>
+        <button type="button" className="primary" onClick={() => onRun('aprobar')} disabled={disabled}>
           Aprobar selección
         </button>
-        <button type="button" onClick={() => onRun('recalcular')} disabled={disabled}>
+        <button type="button" className="secondary" onClick={() => onRun('recalcular')} disabled={disabled}>
           Recalcular métricas
         </button>
-        <button type="button" onClick={() => onRun('cerrar')} disabled={disabled}>
+        <button type="button" className="secondary" onClick={() => onRun('cerrar')} disabled={disabled}>
           Cerrar turno
         </button>
       </div>

--- a/frontend-app/src/modules/operacion/components/OperacionDataGrid.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionDataGrid.tsx
@@ -57,9 +57,9 @@ const OperacionDataGrid: React.FC<Props> = ({ config, registros, onSelect, loadi
         <p>Ocurrió un problema al consultar los datos.</p>
         <small>{message}</small>
         {onRetry && (
-          <button type="button" onClick={onRetry}>
-            Reintentar consulta
-          </button>
+        <button type="button" className="primary" onClick={onRetry}>
+          Reintentar consulta
+        </button>
         )}
       </div>
     );
@@ -69,7 +69,7 @@ const OperacionDataGrid: React.FC<Props> = ({ config, registros, onSelect, loadi
     return (
       <div className="operacion-datagrid operacion-datagrid--placeholder">
         <p>No hay registros que coincidan con los filtros actuales.</p>
-        <button type="button" onClick={() => onSelect([])}>
+        <button type="button" className="secondary" onClick={() => onSelect([])}>
           Limpiar selección
         </button>
       </div>

--- a/frontend-app/src/modules/operacion/components/OperacionFilterBar.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionFilterBar.tsx
@@ -127,20 +127,20 @@ const OperacionFilterBar: React.FC<Props> = ({ config }) => {
               </option>
             ))}
         </select>
-        <button type="button" onClick={handleSaveView}>
+        <button type="button" className="primary" onClick={handleSaveView}>
           Guardar vista
         </button>
         {vistas.length > 0 && (
-          <button type="button" onClick={() => handleShare(vistas[0].id)}>
+          <button type="button" className="secondary" onClick={() => handleShare(vistas[0].id)}>
             Compartir primera vista
           </button>
         )}
         {vistas.length > 0 && (
-          <button type="button" onClick={() => deleteVista(vistas[0].id)}>
+          <button type="button" className="secondary" onClick={() => deleteVista(vistas[0].id)}>
             Eliminar primera vista
           </button>
         )}
-        <button type="button" onClick={resetFiltros}>
+        <button type="button" className="ghost" onClick={resetFiltros}>
           Restablecer filtros
         </button>
       </div>

--- a/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
@@ -81,7 +81,7 @@ const OperacionLayout: React.FC = () => {
     <div className="operacion-module">
       <header className="operacion-header">
         <h1>Operación diaria</h1>
-        <button type="button" onClick={desbloquear} disabled={!resumen?.bloqueado}>
+        <button type="button" className="primary" onClick={desbloquear} disabled={!resumen?.bloqueado}>
           Desbloquear captura
         </button>
       </header>
@@ -135,7 +135,7 @@ const OperacionLayout: React.FC = () => {
             Importación masiva
           </button>
         </div>
-        <button type="button" onClick={reset}>
+        <button type="button" className="primary" onClick={reset}>
           Reiniciar importación
         </button>
       </div>

--- a/frontend-app/src/modules/operacion/operacion.css
+++ b/frontend-app/src/modules/operacion/operacion.css
@@ -52,15 +52,6 @@
   background: #fff;
 }
 
-.operacion-filtros button {
-  padding: 0.5rem 0.75rem;
-  border: none;
-  border-radius: 8px;
-  background: #0a3d62;
-  color: #fff;
-  cursor: pointer;
-}
-
 .operacion-filtros .saved-views {
   display: flex;
   flex-wrap: wrap;
@@ -99,15 +90,6 @@
 .operacion-datagrid--placeholder p {
   margin: 0;
   color: #475569;
-}
-
-.operacion-datagrid--placeholder button {
-  background: #2563eb;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
 }
 
 .operacion-datagrid--placeholder small {
@@ -159,23 +141,6 @@
   border-bottom: 1px solid #e2e8f0;
   gap: 1rem;
   flex-wrap: wrap;
-}
-
-.operacion-toolbar button,
-.operacion-toolbar a {
-  background: #2563eb;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
-  text-decoration: none;
-}
-
-.operacion-toolbar button.secondary {
-  background: transparent;
-  border: 1px solid #2563eb;
-  color: #2563eb;
 }
 
 .operacion-actions {
@@ -241,7 +206,6 @@
 
 .operacion-mass-actions button {
   justify-self: start;
-  background: #16a34a;
 }
 
 .close-day-banner {
@@ -281,11 +245,19 @@
   line-height: 1;
   cursor: pointer;
   color: #475569;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
 }
 
 .operacion-panel-close:hover,
 .operacion-panel-close:focus-visible {
   color: #0f172a;
+  background: rgba(148, 163, 184, 0.2);
 }
 
 .progress-panel .bar {
@@ -325,14 +297,6 @@
 .saved-views select {
   min-width: 160px;
   padding: 0.3rem 0.4rem;
-}
-
-.saved-views button {
-  padding: 0.35rem 0.5rem;
-  border-radius: 6px;
-  border: 1px solid #2563eb;
-  background: #fff;
-  color: #2563eb;
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- add shared button variants (primary, secondary, ghost, danger, small, pill) with consistent hover, focus and disabled states
- refactor configuracion, costos and operacion modules to adopt the shared button styling and remove module-specific button CSS overrides
- align dialogs, alerts and filter/action bars with the new variants for a uniform interaction experience across the app

## Testing
- npm install --loglevel=error *(fails: registry returns 403 Forbidden for @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ee4689b88330bfd7fa59f31000c7