### PR TITLE
Fix configuracion sidebar navigation integration

### DIFF
--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ConfiguracionModule from './modules/configuracion';
 import OperacionModule from './modules/operacion';
 import CostosModule from './modules/costos';
@@ -60,38 +60,68 @@ type EnhancedNavItem = NavItem & {
   isActive?: boolean;
 };
 
-const buildConfiguracionNavigation = (): EnhancedNavItem[] => [
-  {
-    id: 'overview',
-    label: 'Panel general',
-    description: 'Monitorea el estado global de los catálogos y sus dependencias.',
-    icon: <SidebarIcon name="dashboard" />,
-  },
-  {
-    id: 'parametros',
-    label: 'Parámetros generales',
-    description: 'Ajusta políticas y parámetros maestros del sistema.',
-    icon: <SidebarIcon name="sliders" />,
-  },
-  {
-    id: 'centros',
-    label: 'Centros de producción',
-    description: 'Administra ubicaciones, responsables y capacidades.',
-    icon: <SidebarIcon name="factory" />,
-  },
-  {
-    id: 'empleados',
-    label: 'Personal operativo',
-    description: 'Gestiona credenciales, roles y perfiles por área.',
-    icon: <SidebarIcon name="users" />,
-  },
-  {
-    id: 'actividades',
-    label: 'Actividades',
-    description: 'Define etapas de producción y tareas dependientes.',
-    icon: <SidebarIcon name="workflow" />,
-  },
-];
+const buildConfiguracionNavigation = ({
+  activeRouteId,
+  onSelectRoute,
+}: {
+  activeRouteId: string;
+  onSelectRoute: (routeId: string) => void;
+}): EnhancedNavItem[] => {
+  const items: Array<{
+    id: string;
+    label: string;
+    description: string;
+    icon: SidebarIconName;
+    routeId?: string;
+  }> = [
+    {
+      id: 'overview',
+      label: 'Panel general',
+      description: 'Monitorea el estado global de los catálogos y sus dependencias.',
+      icon: 'dashboard',
+    },
+    {
+      id: 'parametros',
+      label: 'Parámetros generales',
+      description: 'Ajusta políticas y parámetros maestros del sistema.',
+      icon: 'sliders',
+      routeId: 'parametros-generales',
+    },
+    {
+      id: 'centros',
+      label: 'Centros de producción',
+      description: 'Administra ubicaciones, responsables y capacidades.',
+      icon: 'factory',
+      routeId: 'centros',
+    },
+    {
+      id: 'empleados',
+      label: 'Personal operativo',
+      description: 'Gestiona credenciales, roles y perfiles por área.',
+      icon: 'users',
+      routeId: 'empleados',
+    },
+    {
+      id: 'actividades',
+      label: 'Actividades',
+      description: 'Define etapas de producción y tareas dependientes.',
+      icon: 'workflow',
+      routeId: 'actividades',
+    },
+  ];
+
+  return items.map((item) => {
+    const routeId = item.routeId;
+    return {
+      id: item.id,
+      label: item.label,
+      description: item.description,
+      icon: <SidebarIcon name={item.icon} />,
+      onSelect: routeId ? () => onSelectRoute(routeId) : undefined,
+      isActive: routeId ? routeId === activeRouteId : false,
+    };
+  });
+};
 
 const domainConfigs: Record<DomainKey, DomainConfig> = {
   configuracion: {
@@ -300,11 +330,22 @@ function App() {
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
   const [openSections, setOpenSections] = useState({ overview: true, shortcuts: false });
   const [activeDomain, setActiveDomain] = useState<DomainKey>('configuracion');
+  const [configuracionRouteId, setConfiguracionRouteId] = useState('actividades');
   const [operacionModulo, setOperacionModulo] = useState<OperacionModulo>('consumos');
   const [costosModulo, setCostosModulo] = useState<CostosSubModulo>('gastos');
 
   const operacionRoutes = useMemo(() => buildOperacionRoutes(), []);
   const costosRoutes = useMemo(() => buildCostosRoutes(), []);
+  const handleConfiguracionRouteChange = useCallback(
+    (routeId: string) => {
+      setConfiguracionRouteId(routeId);
+      if (isCompactViewport) {
+        setIsSidebarVisible(false);
+      }
+    },
+    [isCompactViewport, setIsSidebarVisible]
+  );
+
   const navigationItems = useMemo<EnhancedNavItem[]>(() => {
     if (activeDomain === 'operacion') {
       return operacionRoutes.map((route) => ({
@@ -336,7 +377,10 @@ function App() {
         isActive: route.id === costosModulo,
       }));
     }
-    return buildConfiguracionNavigation();
+    return buildConfiguracionNavigation({
+      activeRouteId: configuracionRouteId,
+      onSelectRoute: handleConfiguracionRouteChange,
+    });
   }, [
     activeDomain,
     operacionRoutes,
@@ -345,6 +389,8 @@ function App() {
     costosModulo,
     isCompactViewport,
     setIsSidebarVisible,
+    configuracionRouteId,
+    handleConfiguracionRouteChange,
   ]);
 
   const domainConfig = domainConfigs[activeDomain];
@@ -505,8 +551,9 @@ function App() {
                         type="button"
                         className="app-sidebar__nav-item"
                         aria-label={item.label}
-                        tabIndex={0}
+                        tabIndex={item.onSelect ? 0 : -1}
                         onClick={item.onSelect}
+                        disabled={!item.onSelect}
                         data-active={item.isActive ?? false}
                         aria-pressed={item.isActive ?? undefined}
                         aria-current={item.isActive ? 'page' : undefined}
@@ -574,7 +621,10 @@ function App() {
 
           <main className="app-main">
             {activeDomain === 'configuracion' ? (
-              <ConfiguracionModule />
+              <ConfiguracionModule
+                activeRouteId={configuracionRouteId}
+                onRouteChange={handleConfiguracionRouteChange}
+              />
             ) : activeDomain === 'operacion' ? (
               <OperacionModule initialModulo={operacionModulo} />
             ) : (

--- a/frontend-app/src/modules/configuracion/index.tsx
+++ b/frontend-app/src/modules/configuracion/index.tsx
@@ -10,7 +10,12 @@ import { buildConfigRoutes } from './routes';
 import { filterRoutesByFeatureFlags, getSyncStatus } from './utils/moduleState';
 import './configuracion.css';
 
-const ConfiguracionModule: React.FC = () => {
+interface ConfiguracionModuleProps {
+  activeRouteId?: string;
+  onRouteChange?: (routeId: string) => void;
+}
+
+const ConfiguracionModule: React.FC<ConfiguracionModuleProps> = ({ activeRouteId, onRouteChange }) => {
   const featureFlags = useFeatureFlags();
 
   const routes = useMemo(() => {
@@ -29,7 +34,7 @@ const ConfiguracionModule: React.FC = () => {
 
   return (
     <ToastProvider>
-      <ConfigProvider routes={routes}>
+      <ConfigProvider routes={routes} activeRouteId={activeRouteId} onRouteChange={onRouteChange}>
         <div className="configuracion-module">
           <ConfigBreadcrumbs />
           <ConfigNavBar />


### PR DESCRIPTION
## Summary
- wire the configuración sidebar entries to the underlying catálogo routes so each option loads the expected page
- allow `ConfiguracionModule` to receive the active route and notify the shell when it changes
- extend the configuración context provider to support externally controlled routes and disable sidebar items without actions

## Testing
- `npm run build` *(fails: missing type definitions for `vite/client` and `node` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ee00d6e483308efcd1ed857d2a4c