### PR TITLE
Enhance Costos sidebar cards visuals

### DIFF
--- a/frontend-app/src/modules/costos/components/AllocationBreakdown.tsx
+++ b/frontend-app/src/modules/costos/components/AllocationBreakdown.tsx
@@ -9,7 +9,7 @@ interface AllocationBreakdownProps {
 }
 
 const AllocationBreakdown: React.FC<AllocationBreakdownProps> = ({ items, currency }) => (
-  <section className="costos-card">
+  <section className="costos-card costos-card--highlight">
     <h2>Distribución por centro</h2>
     <p className="costos-metadata">
       Visualiza cómo se distribuye el importe total entre centros para validar prorrateos y asignaciones.

--- a/frontend-app/src/modules/costos/components/AuditTimeline.tsx
+++ b/frontend-app/src/modules/costos/components/AuditTimeline.tsx
@@ -9,7 +9,7 @@ interface AuditTimelineProps {
 const AuditTimeline: React.FC<AuditTimelineProps> = ({ record }) => {
   if (!record) {
     return (
-      <section className="costos-card">
+      <section className="costos-card costos-card--highlight">
         <h2>Auditoría</h2>
         <p className="costos-empty-state">Selecciona un registro para visualizar su historial de auditoría.</p>
       </section>
@@ -17,7 +17,7 @@ const AuditTimeline: React.FC<AuditTimelineProps> = ({ record }) => {
   }
 
   return (
-    <section className="costos-card">
+    <section className="costos-card costos-card--highlight">
       <h2>Auditoría</h2>
       <div className="costos-audit-timeline">
         <div className="costos-audit-entry">

--- a/frontend-app/src/modules/costos/components/BalanceSummary.tsx
+++ b/frontend-app/src/modules/costos/components/BalanceSummary.tsx
@@ -17,7 +17,7 @@ interface BalanceSummaryProps {
 }
 
 const BalanceSummary: React.FC<BalanceSummaryProps> = ({ summary, formatted, onRefresh, isLoading }) => (
-  <section className="costos-card" aria-live="polite">
+  <section className="costos-card costos-card--highlight" aria-live="polite">
     <header className="costos-toolbar">
       <div>
         <h2>Resumen de balances</h2>

--- a/frontend-app/src/modules/costos/components/ProcessLog.tsx
+++ b/frontend-app/src/modules/costos/components/ProcessLog.tsx
@@ -13,7 +13,7 @@ const levelLabel: Record<ProcessLogEntry['level'], string> = {
 };
 
 const ProcessLog: React.FC<ProcessLogProps> = ({ logs }) => (
-  <section className="costos-card">
+  <section className="costos-card costos-card--highlight">
     <h2>Bitácora del proceso</h2>
     {logs.length === 0 ? (
       <p className="costos-empty-state">Aún no se registran eventos para el proceso en curso.</p>

--- a/frontend-app/src/modules/costos/components/TrendChart.tsx
+++ b/frontend-app/src/modules/costos/components/TrendChart.tsx
@@ -28,7 +28,7 @@ const TrendChart: React.FC<TrendChartProps> = ({ points }) => {
   }, [points]);
 
   return (
-    <section className="costos-card">
+    <section className="costos-card costos-card--highlight">
       <h2>Tendencia del periodo</h2>
       <p className="costos-metadata">
         Evolución del total registrado por periodo de cálculo. Utiliza la variación para identificar anomalías.

--- a/frontend-app/src/modules/costos/costos.css
+++ b/frontend-app/src/modules/costos/costos.css
@@ -124,9 +124,22 @@
   gap: 20px;
 }
 
+.costos-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: sticky;
+  top: 96px;
+  align-self: flex-start;
+}
+
 @media (max-width: 1200px) {
   .costos-layout {
     grid-template-columns: 1fr;
+  }
+
+  .costos-sidebar {
+    position: static;
   }
 }
 
@@ -139,6 +152,44 @@
   flex-direction: column;
   gap: 12px;
   box-shadow: var(--shadow-level-1);
+}
+
+.costos-card--highlight {
+  position: relative;
+  padding-left: 28px;
+  border-color: rgba(20, 94, 168, 0.28);
+  background: linear-gradient(145deg, rgba(20, 94, 168, 0.16), rgba(15, 23, 42, 0));
+  box-shadow: 0 18px 36px -20px rgba(15, 23, 42, 0.5);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  overflow: hidden;
+}
+
+.costos-card--highlight::before {
+  content: '';
+  position: absolute;
+  top: 18px;
+  bottom: 18px;
+  left: 12px;
+  width: 4px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, var(--color-primary), var(--color-primary-variant));
+  opacity: 0.9;
+}
+
+.costos-card--highlight:hover,
+.costos-card--highlight:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 40px -18px rgba(15, 23, 42, 0.55);
+}
+
+.costos-card--highlight h2 {
+  color: var(--color-primary-variant);
+  letter-spacing: 0.01em;
+}
+
+.costos-card--highlight .costos-metadata,
+.costos-card--highlight .costos-summary-item span:last-child {
+  color: rgba(20, 94, 168, 0.75);
 }
 
 .costos-card h2 {


### PR DESCRIPTION
## Summary
- highlight the informational cards in the Costos sidebar with a dedicated visual style and subtle hover/focus transitions
- make the sidebar stack sticky within the layout to keep the KPIs visible while scrolling and emphasize metadata tones

## Testing
- npm run build *(fails: TypeScript cannot resolve `vite/client` and `node` typings in the current container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6ee9d1bfc833091a0c25e6c2bcd41