### PR TITLE
feat: add analytics reporting module

### DIFF
--- a/frontend-app/package-lock.json
+++ b/frontend-app/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "recharts": "^2.15.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",

--- a/frontend-app/package.json
+++ b/frontend-app/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "recharts": "^2.15.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -3,11 +3,14 @@ import ConfiguracionModule from './modules/configuracion';
 import OperacionModule from './modules/operacion';
 import CostosModule from './modules/costos';
 import ImportacionesModule from './modules/importaciones';
+import ReportesModule from './modules/reportes';
 import { buildOperacionRoutes } from './modules/operacion/routes';
 import { buildCostosRoutes } from './modules/costos/routes';
+import { buildReportesRoutes } from './modules/reportes/routes';
 import type { OperacionModulo } from './modules/operacion/types';
 import type { CostosSubModulo } from './modules/costos/types';
 import type { ImportacionesSection } from './modules/importaciones/types';
+import type { ReportCategory } from './modules/reportes/types';
 import './App.css';
 
 type NavItem = {
@@ -16,7 +19,7 @@ type NavItem = {
   description: string;
   icon: JSX.Element;
 };
-type DomainKey = 'configuracion' | 'operacion' | 'importaciones' | 'costos';
+type DomainKey = 'configuracion' | 'operacion' | 'importaciones' | 'costos' | 'reportes';
 
 type DomainAction = {
   label: string;
@@ -57,7 +60,10 @@ type SidebarIconName =
   | 'sueldos'
   | 'prorrateo'
   | 'importar'
-  | 'bitacoras';
+  | 'bitacoras'
+  | 'financieros'
+  | 'operativos-reportes'
+  | 'auditoria-reportes';
 
 const importacionesNavigation: { id: ImportacionesSection; label: string; description: string; icon: SidebarIconName }[] = [
   {
@@ -205,6 +211,27 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     },
     shortcuts: ['Ver existencias', 'Ir a asientos', 'Descargar bitácora'],
   },
+  reportes: {
+    eyebrow: 'Suite Herbal ERP · Analítica',
+    title: 'Reportes y analítica',
+    subtitle:
+      'Explora indicadores financieros, operativos y de auditoría con filtros avanzados y exportaciones seguras.',
+    logo: '📊',
+    actions: [
+      { label: 'Descargar guía rápida' },
+      { label: 'Solicitar nuevo reporte', variant: 'primary' },
+    ],
+    overview: {
+      description:
+        'Comparte vistas filtradas, monitorea descargas recientes y asegura el cumplimiento de los indicadores clave.',
+      stats: [
+        { value: '7', label: 'Reportes disponibles' },
+        { value: '3', label: 'Descargas hoy' },
+        { value: 'AA', label: 'Nivel de accesibilidad' },
+      ],
+    },
+    shortcuts: ['Ver KPIs financieros', 'Explorar consumos', 'Auditar exportaciones'],
+  },
   importaciones: {
     eyebrow: 'Suite Herbal ERP · Importaciones',
     title: 'Importación de bases Access',
@@ -233,6 +260,7 @@ const domainEntries: { id: DomainKey; label: string }[] = [
   { id: 'operacion', label: 'Operación diaria' },
   { id: 'importaciones', label: 'Importaciones MDB' },
   { id: 'costos', label: 'Costos y consolidaciones' },
+  { id: 'reportes', label: 'Reportes y analítica' },
 ];
 
 function SidebarIcon({ name }: { name: SidebarIconName }) {
@@ -378,6 +406,33 @@ function SidebarIcon({ name }: { name: SidebarIconName }) {
           />
         </svg>
       );
+    case 'financieros':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M4 4h4v16H4zm6 6h4v10h-4zm6-4h4v14h-4z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'operativos-reportes':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M3 5h18v2H3zm0 6h12v2H3zm0 6h18v2H3zM19 9h2v2h-2zm-4 6h2v2h-2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'auditoria-reportes':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M12 2a10 10 0 1 0 10 10h-2a8 8 0 1 1-8-8v2l4-3-4-3v2zM9 11h2v5H9zm4 0h2v5h-2z"
+            fill="currentColor"
+          />
+        </svg>
+      );
     default:
       return null;
   }
@@ -393,9 +448,11 @@ function App() {
   const [operacionModulo, setOperacionModulo] = useState<OperacionModulo>('consumos');
   const [costosModulo, setCostosModulo] = useState<CostosSubModulo>('gastos');
   const [importacionesSection, setImportacionesSection] = useState<ImportacionesSection>('importar');
+  const [reportesCategory, setReportesCategory] = useState<ReportCategory>('financieros');
 
   const operacionRoutes = useMemo(() => buildOperacionRoutes(), []);
   const costosRoutes = useMemo(() => buildCostosRoutes(), []);
+  const reportesRoutes = useMemo(() => buildReportesRoutes(), []);
   const handleConfiguracionRouteChange = useCallback(
     (routeId: string) => {
       setConfiguracionRouteId(routeId);
@@ -437,6 +494,29 @@ function App() {
         isActive: route.id === costosModulo,
       }));
     }
+    if (activeDomain === 'reportes') {
+      return reportesRoutes.map((route) => {
+        const iconName: SidebarIconName =
+          route.id === 'financieros'
+            ? 'financieros'
+            : route.id === 'operativos'
+              ? 'operativos-reportes'
+              : 'auditoria-reportes';
+        return {
+          id: route.id,
+          label: route.title,
+          description: route.description,
+          icon: <SidebarIcon name={iconName} />,
+          onSelect: () => {
+            setReportesCategory(route.id);
+            if (isCompactViewport) {
+              setIsSidebarVisible(false);
+            }
+          },
+          isActive: route.id === reportesCategory,
+        };
+      });
+    }
     return buildConfiguracionNavigation({
       activeRouteId: configuracionRouteId,
       onSelectRoute: handleConfiguracionRouteChange,
@@ -448,6 +528,8 @@ function App() {
     operacionModulo,
     costosRoutes,
     costosModulo,
+    reportesRoutes,
+    reportesCategory,
     importacionesSection,
     isCompactViewport,
     setIsSidebarVisible,
@@ -694,6 +776,8 @@ function App() {
                 activeSection={importacionesSection}
                 onSectionChange={setImportacionesSection}
               />
+            ) : activeDomain === 'reportes' ? (
+              <ReportesModule activeCategory={reportesCategory} onCategoryChange={setReportesCategory} />
             ) : (
               <CostosModule initialSubmodule={costosModulo} />
             )}

--- a/frontend-app/src/lib/router/useSearchParams.ts
+++ b/frontend-app/src/lib/router/useSearchParams.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export type SearchParamsInit =
+  | URLSearchParams
+  | string
+  | [string, string][]
+  | Record<string, string | number | boolean | undefined | null | (string | number | boolean)[]>;
+
+function normalizeInit(init?: SearchParamsInit): URLSearchParams {
+  if (!init) {
+    return new URLSearchParams();
+  }
+
+  if (init instanceof URLSearchParams) {
+    return new URLSearchParams(init.toString());
+  }
+
+  if (typeof init === 'string') {
+    return new URLSearchParams(init);
+  }
+
+  if (Array.isArray(init)) {
+    return new URLSearchParams(init);
+  }
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(init)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        params.append(key, String(item));
+      }
+    } else {
+      params.set(key, String(value));
+    }
+  }
+  return params;
+}
+
+interface SetSearchParamsOptions {
+  replace?: boolean;
+}
+
+export function useSearchParams(
+  defaultInit?: SearchParamsInit,
+): [URLSearchParams, (nextInit: SearchParamsInit, options?: SetSearchParamsOptions) => void] {
+  const initialParams = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return normalizeInit(defaultInit);
+    }
+    const current = window.location.search;
+    if (current) {
+      return new URLSearchParams(current);
+    }
+    return normalizeInit(defaultInit);
+  }, [defaultInit]);
+
+  const [params, setParams] = useState<URLSearchParams>(initialParams);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handlePopState = () => {
+      setParams(new URLSearchParams(window.location.search));
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const update = useCallback(
+    (nextInit: SearchParamsInit, options: SetSearchParamsOptions = {}) => {
+      const nextParams = normalizeInit(nextInit);
+      setParams(nextParams);
+
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const search = nextParams.toString();
+      const nextUrl = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
+      const historyMethod = options.replace ? 'replaceState' : 'pushState';
+      window.history[historyMethod](null, '', nextUrl);
+    },
+    [],
+  );
+
+  return [params, update];
+}
+
+export function mergeSearchParams(
+  base: URLSearchParams,
+  patch: Record<string, string | undefined>,
+): URLSearchParams {
+  const next = new URLSearchParams(base.toString());
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+  }
+  return next;
+}

--- a/frontend-app/src/modules/reportes/__tests__/filters.test.ts
+++ b/frontend-app/src/modules/reportes/__tests__/filters.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildShareableLink,
+  compareFilters,
+  normalizeCentro,
+  normalizePeriodo,
+  normalizeProducto,
+  parseFiltersFromSearch,
+  serializeFiltersToSearch,
+} from '../utils/filters.js';
+
+test('normalizePeriodo acepta YYYY-MM y lo convierte a primer día', () => {
+  assert.equal(normalizePeriodo('2024-05'), '2024-05-01');
+  assert.equal(normalizePeriodo('2024-05-01'), '2024-05-01');
+  assert.equal(typeof normalizePeriodo('2024-05-15'), 'string');
+  assert.equal(normalizePeriodo('no-date'), undefined);
+});
+
+test('normalizeCentro filtra valores inválidos', () => {
+  assert.equal(normalizeCentro(' 101 '), '101');
+  assert.equal(normalizeCentro('abc'), undefined);
+  assert.equal(normalizeCentro(null), undefined);
+});
+
+test('serialize y parse mantienen filtros equivalentes', () => {
+  const filters = { periodo: '2024-05-01', producto: 'Queso', centro: '200' };
+  const params = serializeFiltersToSearch(filters);
+  const parsed = parseFiltersFromSearch(params);
+  assert.deepEqual(parsed, filters);
+});
+
+test('compareFilters detecta diferencias', () => {
+  const a = { periodo: '2024-05-01', producto: 'Queso' };
+  const b = { periodo: '2024-05-01', producto: 'Queso' };
+  const c = { periodo: '2024-04-01', producto: 'Queso' };
+  assert.equal(compareFilters(a, b), true);
+  assert.equal(compareFilters(a, c), false);
+});
+
+test('buildShareableLink incluye parámetros esperados', () => {
+  if (typeof window === 'undefined') {
+    globalThis.window = {
+      location: {
+        origin: 'http://localhost',
+        pathname: '/reportes',
+        hash: '',
+      },
+      history: {
+        pushState: () => {},
+        replaceState: () => {},
+      },
+    } as unknown as Window & typeof globalThis;
+  }
+  const link = buildShareableLink({ periodo: '2024-05-01', centro: '101' });
+  assert.equal(link.includes('periodo=2024-05-01'), true);
+  assert.equal(link.includes('centro=101'), true);
+});
+
+test('normalizeProducto elimina espacios extra', () => {
+  assert.equal(normalizeProducto('  Crema '), 'Crema');
+  assert.equal(normalizeProducto('   '), undefined);
+});

--- a/frontend-app/src/modules/reportes/api/reportesApi.ts
+++ b/frontend-app/src/modules/reportes/api/reportesApi.ts
@@ -1,0 +1,191 @@
+import apiClient from '@/lib/http/apiClient';
+import type {
+  ComparisonInsight,
+  ComparisonPoint,
+  ExportProgress,
+  ReportDownloadLog,
+  ReportFilters,
+  ReportFormat,
+  ReportId,
+  ReportSummaryCard,
+  ReportTableDescriptor,
+} from '../types';
+import {
+  buildComparisonInsight,
+  buildCostosSummaryCards,
+  normalizeAsignacionesResponse,
+  normalizeComparativoResponse,
+  normalizeConsumosResponse,
+  normalizeCostosResponse,
+  normalizeCifResponse,
+  normalizeDownloadLog,
+  normalizeManoObraResponse,
+} from '../utils/normalizers';
+import { serializeFiltersToSearch } from '../utils/filters';
+
+const endpointMap: Record<ReportId, string> = {
+  costos: '/api/reportes/costos',
+  comparativo: '/api/reportes/comparativo',
+  cif: '/api/reportes/cif',
+  consumos: '/api/reportes/consumos',
+  asignaciones: '/api/reportes/asignaciones',
+  'mano-obra': '/api/reportes/mano-obra',
+  descargas: '/api/reportes/descargas',
+};
+
+interface FetchCostosResult {
+  tables: ReportTableDescriptor[];
+  cards: ReportSummaryCard[];
+}
+
+export async function fetchCostosReport(filters: ReportFilters): Promise<FetchCostosResult> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('costos', query));
+  const normalized = normalizeCostosResponse(response);
+  const cards = buildCostosSummaryCards(normalized);
+
+  const costosTable: ReportTableDescriptor = {
+    id: 'costos-centro',
+    title: 'Costos por centro',
+    description: 'Montos consolidados por centro de costos.',
+    columns: [
+      { id: 'centro', label: 'Centro' },
+      { id: 'monto', label: 'Monto', align: 'right', isNumeric: true },
+    ],
+    rows: normalized.costos.map((item) => ({
+      centro: item.centro,
+      monto: new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(item.monto),
+    })),
+    emptyMessage: 'Sin registros de costos para el periodo solicitado.',
+  };
+
+  const consumosTable: ReportTableDescriptor = {
+    id: 'consumos-producto',
+    title: 'Consumos por producto',
+    description: 'Totales consumidos durante el periodo.',
+    columns: [
+      { id: 'producto', label: 'Producto' },
+      { id: 'cantidad', label: 'Cantidad', align: 'right', isNumeric: true },
+    ],
+    rows: normalized.consumos.map((item) => ({
+      producto: item.producto,
+      cantidad: new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+        item.cantidad,
+      ),
+    })),
+    emptyMessage: 'No se registraron consumos en el periodo seleccionado.',
+  };
+
+  const cifTable = normalizeCifResponse(normalized.cif);
+
+  return {
+    tables: [costosTable, consumosTable, cifTable],
+    cards,
+  };
+}
+
+export async function fetchComparativoReport(
+  filters: ReportFilters,
+): Promise<{ points: ComparisonPoint[]; insight: ComparisonInsight }> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('comparativo', query));
+  return {
+    points: normalizeComparativoResponse(response),
+    insight: buildComparisonInsight(response),
+  };
+}
+
+export async function fetchConsumosReport(filters: ReportFilters): Promise<ReportTableDescriptor> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('consumos', query));
+  return normalizeConsumosResponse(response);
+}
+
+export async function fetchAsignacionesReport(filters: ReportFilters): Promise<ReportTableDescriptor> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('asignaciones', query));
+  return normalizeAsignacionesResponse(response);
+}
+
+export async function fetchManoObraReport(filters: ReportFilters): Promise<ReportTableDescriptor> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('mano-obra', query));
+  return normalizeManoObraResponse(response);
+}
+
+export async function fetchDownloadLog(filters: ReportFilters): Promise<ReportDownloadLog[]> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('descargas', query));
+  return normalizeDownloadLog(response);
+}
+
+const MAX_EXPORT_ROWS = 50000;
+
+interface ExportReportResponse {
+  url?: string;
+  rowCount?: number;
+}
+
+export async function exportReport(
+  reportId: ReportId,
+  filters: ReportFilters,
+  format: Exclude<ReportFormat, 'json'>,
+): Promise<ExportProgress> {
+  const query = serializeFiltersToSearch({ ...filters, format }).toString();
+  const url = `${endpointMap[reportId]}${query ? `?${query}` : ''}`;
+
+  const progress: ExportProgress = {
+    status: 'preparing',
+    percentage: 10,
+    message: 'Preparando exportación…',
+  };
+
+  const response = await apiClient.get<ExportReportResponse>(url, {
+    headers: {
+      Accept:
+        format === 'csv'
+          ? 'text/csv'
+          : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    },
+  });
+
+  const rowCount = Number(response?.rowCount ?? 0);
+  if (rowCount > MAX_EXPORT_ROWS) {
+    return {
+      status: 'error',
+      percentage: 100,
+      error: `La exportación excede el máximo permitido de ${MAX_EXPORT_ROWS.toLocaleString('es-MX')} filas. Ajusta los filtros y vuelve a intentar.`,
+    };
+  }
+
+  return {
+    status: 'completed',
+    percentage: 100,
+    message: 'Exportación lista.',
+    downloadUrl: response?.url,
+    rowCount,
+  };
+}
+
+export async function logDownload(
+  reportId: ReportId,
+  filters: ReportFilters,
+  format: Exclude<ReportFormat, 'json'>,
+  status: 'completed' | 'failed',
+  rowCount: number,
+): Promise<void> {
+  await apiClient.post('/api/reportes/auditoria', {
+    reportId,
+    filters,
+    format,
+    status,
+    rowCount,
+    downloadedAt: new Date().toISOString(),
+  });
+}
+
+function buildUrl(reportId: ReportId, params: URLSearchParams): string {
+  const base = endpointMap[reportId];
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}

--- a/frontend-app/src/modules/reportes/components/AdvancedFilters.tsx
+++ b/frontend-app/src/modules/reportes/components/AdvancedFilters.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo, useState } from 'react';
+import { useReportesContext } from '../context/ReportesContext';
+import type { ReportFilters } from '../types';
+import { normalizeCentro, normalizePeriodo, normalizeProducto } from '../utils/filters';
+
+interface AdvancedFiltersProps {
+  descriptors: Array<{ id: keyof ReportFilters; label: string; helper?: string }>;
+}
+
+const formatOptions = [
+  { value: 'json', label: 'JSON' },
+  { value: 'csv', label: 'CSV' },
+  { value: 'xlsx', label: 'Excel' },
+];
+
+const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({ descriptors }) => {
+  const { filters, updateFilters, resetFilters, isValidCombination, shareableLink, presets, savePreset, applyPreset, deletePreset } =
+    useReportesContext();
+  const [presetName, setPresetName] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const descriptorMap = useMemo(() => {
+    const map = new Map<keyof ReportFilters, { label: string; helper?: string }>();
+    descriptors.forEach((descriptor) => map.set(descriptor.id, descriptor));
+    return map;
+  }, [descriptors]);
+
+  const handlePeriodoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = normalizePeriodo(event.target.value);
+    updateFilters({ periodo: value });
+  };
+
+  const handleProductoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = normalizeProducto(event.target.value);
+    updateFilters({ producto: value });
+  };
+
+  const handleCentroChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = normalizeCentro(event.target.value);
+    updateFilters({ centro: value });
+  };
+
+  const handleFormatChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    updateFilters({ format: event.target.value as ReportFilters['format'] });
+  };
+
+  const handleCopyLink = async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(shareableLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('No fue posible copiar el enlace', error);
+    }
+  };
+
+  const handleSavePreset = () => {
+    if (!presetName.trim()) return;
+    savePreset(presetName.trim());
+    setPresetName('');
+  };
+
+  return (
+    <aside className="reportes-module__filters">
+      <header>
+        <h2>Filtros avanzados</h2>
+        <p>Configura los criterios de consulta y comparte la vista con tu equipo.</p>
+      </header>
+
+      <label>
+        <span>{descriptorMap.get('periodo')?.label ?? 'Periodo (mes)'}</span>
+        <input
+          type="month"
+          value={filters.periodo ? filters.periodo.slice(0, 7) : ''}
+          onChange={handlePeriodoChange}
+          aria-describedby="periodo-helper"
+        />
+        {descriptorMap.get('periodo')?.helper && (
+          <small id="periodo-helper">{descriptorMap.get('periodo')?.helper}</small>
+        )}
+      </label>
+
+      <label>
+        <span>{descriptorMap.get('producto')?.label ?? 'Producto'}</span>
+        <input
+          type="text"
+          value={filters.producto ?? ''}
+          onChange={handleProductoChange}
+          placeholder="Nombre o clave de producto"
+        />
+      </label>
+
+      <label>
+        <span>{descriptorMap.get('centro')?.label ?? 'Centro'}</span>
+        <input
+          type="number"
+          min={0}
+          value={filters.centro ?? ''}
+          onChange={handleCentroChange}
+          placeholder="ID de centro"
+        />
+      </label>
+
+      <label>
+        <span>Formato preferido</span>
+        <select value={filters.format ?? 'json'} onChange={handleFormatChange}>
+          {formatOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="reportes-export-bar" role="group" aria-label="Acciones de filtros">
+        <button type="button" onClick={resetFilters}>
+          Limpiar filtros
+        </button>
+        <button type="button" onClick={handleCopyLink} disabled={!isValidCombination}>
+          {copied ? 'Enlace copiado' : 'Compartir vista'}
+        </button>
+        {!isValidCombination && (
+          <span role="alert" className="reportes-export-bar__status">
+            Selecciona un periodo para filtrar por centro.
+          </span>
+        )}
+      </div>
+
+      <section className="reportes-presets" aria-label="Presets guardados">
+        <header>
+          <h3>Presets</h3>
+          <p>Guarda combinaciones frecuentes para reutilizarlas.</p>
+        </header>
+        <div>
+          <label>
+            <span>Nombre del preset</span>
+            <input
+              type="text"
+              value={presetName}
+              onChange={(event) => setPresetName(event.target.value)}
+              placeholder="Ej. Cierre mensual"
+            />
+          </label>
+          <button type="button" onClick={handleSavePreset} disabled={!presetName.trim()}>
+            Guardar preset
+          </button>
+        </div>
+
+        <div className="reportes-presets__list" role="list">
+          {presets.map((preset) => (
+            <div key={preset.id} className="reportes-presets__item" role="listitem">
+              <div>
+                <span className="reportes-presets__name">{preset.name}</span>
+                <div className="reportes-presets__meta">
+                  Guardado el {new Date(preset.createdAt).toLocaleDateString('es-MX')}
+                </div>
+              </div>
+              <div>
+                <button type="button" onClick={() => applyPreset(preset.id)}>
+                  Aplicar
+                </button>
+                <button type="button" onClick={() => deletePreset(preset.id)} aria-label={`Eliminar ${preset.name}`}>
+                  ✕
+                </button>
+              </div>
+            </div>
+          ))}
+          {presets.length === 0 && <p>No hay presets guardados aún.</p>}
+        </div>
+      </section>
+    </aside>
+  );
+};
+
+export default AdvancedFilters;

--- a/frontend-app/src/modules/reportes/components/ComparisonChart.tsx
+++ b/frontend-app/src/modules/reportes/components/ComparisonChart.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ComparisonInsight, ComparisonPoint } from '../types';
+
+interface ComparisonChartProps {
+  data: ComparisonPoint[];
+  insight: ComparisonInsight;
+}
+
+const ComparisonChart: React.FC<ComparisonChartProps> = ({ data, insight }) => (
+  <figure aria-label="Comparativo de egresos vs insumos" role="group">
+    <div style={{ width: '100%', height: 320 }}>
+      <ResponsiveContainer>
+        <BarChart data={data} barGap={12} role="img" aria-label="Gráfico comparativo de egresos e insumos">
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis tickFormatter={(value) => new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(value)} />
+          <Tooltip
+            formatter={(value: number) =>
+              new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(value)
+            }
+            contentStyle={{ backgroundColor: '#0f172a', color: '#f8fafc', borderRadius: 12 }}
+          />
+          <Legend />
+          <Bar dataKey="egresos" name="Egresos" fill="#1d4ed8" radius={[12, 12, 0, 0]} />
+          <Bar dataKey="insumos" name="Insumos" fill="#0ea5e9" radius={[12, 12, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+    <figcaption>
+      <strong>{insight.differenceLabel}</strong>
+      <p>{insight.statusLabel}</p>
+      <span role="status" aria-live="polite">
+        {insight.consistent ? '✅ Totales consistentes' : '⚠️ Revisión requerida'}
+      </span>
+    </figcaption>
+  </figure>
+);
+
+export default ComparisonChart;

--- a/frontend-app/src/modules/reportes/components/DownloadLogTable.tsx
+++ b/frontend-app/src/modules/reportes/components/DownloadLogTable.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import type { ReportDownloadLog } from '../types';
+
+interface DownloadLogTableProps {
+  logs: ReportDownloadLog[];
+}
+
+const DownloadLogTable: React.FC<DownloadLogTableProps> = ({ logs }) => {
+  if (!logs || logs.length === 0) {
+    return (
+      <div className="reportes-empty-state" role="status" aria-live="polite">
+        <h4>Sin descargas registradas</h4>
+        <p>Aún no se han registrado descargas con los filtros seleccionados.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="reportes-table-wrapper">
+      <table className="reportes-table" aria-label="Bitácora de descargas">
+        <thead>
+          <tr>
+            <th scope="col">Reporte</th>
+            <th scope="col">Formato</th>
+            <th scope="col">Filtrado</th>
+            <th scope="col">Solicitado por</th>
+            <th scope="col">Solicitado</th>
+            <th scope="col">Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => (
+            <tr key={log.id}>
+              <td>{log.reportId}</td>
+              <td>{log.format.toUpperCase()}</td>
+              <td>
+                {Object.entries(log.filters).map(([key, value]) => (
+                  <div key={key}>
+                    <strong>{key}:</strong> {value ?? '—'}
+                  </div>
+                ))}
+              </td>
+              <td>{log.createdBy}</td>
+              <td>{new Date(log.requestedAt).toLocaleString('es-MX')}</td>
+              <td>{log.status === 'completed' ? 'Completado' : log.status === 'failed' ? 'Fallido' : 'Pendiente'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default DownloadLogTable;

--- a/frontend-app/src/modules/reportes/components/ExportToolbar.tsx
+++ b/frontend-app/src/modules/reportes/components/ExportToolbar.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import type { ExportProgress, ReportFormat, ReportId } from '../types';
+import { useReportExport } from '../hooks/useReportExport';
+
+interface ExportToolbarProps {
+  reportId: ReportId;
+  disabled?: boolean;
+}
+
+const statusMessageMap: Record<ExportProgress['status'], string> = {
+  idle: 'Listo para exportar',
+  preparing: 'Preparando exportación…',
+  downloading: 'Descargando…',
+  completed: 'Exportación completada',
+  error: 'Error en la exportación',
+};
+
+const ExportToolbar: React.FC<ExportToolbarProps> = ({ reportId, disabled }) => {
+  const { progress, exportAsCsv, exportAsXlsx } = useReportExport(reportId);
+
+  const isBusy = progress.status === 'preparing' || progress.status === 'downloading';
+  const canExport = !disabled && progress.status !== 'error';
+
+  const handleExport = (format: Exclude<ReportFormat, 'json'>) => {
+    if (format === 'csv') {
+      void exportAsCsv();
+    } else {
+      void exportAsXlsx();
+    }
+  };
+
+  return (
+    <div className="reportes-export-bar" role="group" aria-label="Exportar resultados">
+      <button type="button" onClick={() => handleExport('csv')} disabled={!canExport || isBusy}>
+        Descargar CSV
+      </button>
+      <button type="button" onClick={() => handleExport('xlsx')} disabled={!canExport || isBusy}>
+        Descargar Excel
+      </button>
+      <span className="reportes-export-bar__status" role="status" aria-live="polite">
+        {statusMessageMap[progress.status]}
+        {progress.status === 'error' && progress.error ? ` · ${progress.error}` : ''}
+      </span>
+    </div>
+  );
+};
+
+export default ExportToolbar;

--- a/frontend-app/src/modules/reportes/components/ReportSection.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface ReportSectionProps {
+  title: string;
+  description: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const ReportSection: React.FC<ReportSectionProps> = ({ title, description, actions, children }) => (
+  <section className="reportes-module__section">
+    <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
+      <div>
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </div>
+      {actions && <div>{actions}</div>}
+    </header>
+    <div>{children}</div>
+  </section>
+);
+
+export default ReportSection;

--- a/frontend-app/src/modules/reportes/components/ReportSkeleton.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportSkeleton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ReportSkeleton: React.FC = () => (
+  <div className="reportes-skeleton" aria-hidden="true">
+    <div className="reportes-skeleton__card" />
+    <div className="reportes-skeleton__card" />
+    <div className="reportes-skeleton__table" />
+  </div>
+);
+
+export default ReportSkeleton;

--- a/frontend-app/src/modules/reportes/components/ReportSummaryCards.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportSummaryCards.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import type { ReportSummaryCard } from '../types';
+
+interface ReportSummaryCardsProps {
+  cards: ReportSummaryCard[];
+}
+
+const toneClassMap: Record<Exclude<ReportSummaryCard['tone'], undefined>, string> = {
+  default: '',
+  success: 'reportes-summary-card--success',
+  warning: 'reportes-summary-card--warning',
+  danger: 'reportes-summary-card--danger',
+};
+
+const ReportSummaryCards: React.FC<ReportSummaryCardsProps> = ({ cards }) => {
+  if (!cards || cards.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Indicadores clave" className="reportes-summary-cards">
+      {cards.map((card) => {
+        const toneClass = card.tone ? toneClassMap[card.tone] ?? '' : '';
+        return (
+          <article key={card.id} className={`reportes-summary-card ${toneClass}`.trim()}>
+            <span className="reportes-summary-card__label">{card.label}</span>
+            <span className="reportes-summary-card__value" aria-live="polite">
+              {card.value}
+            </span>
+            {card.helpText && <p className="reportes-summary-card__help">{card.helpText}</p>}
+          </article>
+        );
+      })}
+    </section>
+  );
+};
+
+export default ReportSummaryCards;

--- a/frontend-app/src/modules/reportes/components/ReportTable.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportTable.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import type { ReportTableDescriptor } from '../types';
+
+interface ReportTableProps<Row extends Record<string, unknown>> {
+  descriptor: ReportTableDescriptor<Row>;
+}
+
+function isNumericColumn(value: unknown): value is number {
+  return typeof value === 'number' || (typeof value === 'string' && /^-?\d+[\d,.]*$/.test(value));
+}
+
+const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: ReportTableProps<Row>) => {
+  if (!descriptor.rows || descriptor.rows.length === 0) {
+    return (
+      <div className="reportes-empty-state" role="status" aria-live="polite">
+        <h4>Sin datos</h4>
+        <p>{descriptor.emptyMessage ?? 'No se encontraron resultados para los filtros seleccionados.'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="reportes-table-wrapper">
+      <table className="reportes-table" role="grid" aria-label={descriptor.title}>
+        <caption className="sr-only">{descriptor.description}</caption>
+        <thead>
+          <tr>
+            {descriptor.columns.map((column) => (
+              <th
+                key={String(column.id)}
+                scope="col"
+                className={column.isNumeric ? 'reportes-table__numeric' : undefined}
+              >
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {descriptor.rows.map((row, index) => (
+            <tr key={index}>
+              {descriptor.columns.map((column) => {
+                const value = row[column.id];
+                const isNumeric = column.isNumeric ?? isNumericColumn(value);
+                return (
+                  <td
+                    key={String(column.id)}
+                    className={isNumeric ? 'reportes-table__numeric' : undefined}
+                    data-column={column.label}
+                  >
+                    {value === undefined || value === null || value === '' ? '—' : String(value)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+        {descriptor.totalRow && (
+          <tfoot>
+            <tr>
+              {descriptor.columns.map((column, columnIndex) => {
+                const value = descriptor.totalRow?.[column.id];
+                return (
+                  <td
+                    key={String(column.id)}
+                    className={column.isNumeric ? 'reportes-table__numeric' : undefined}
+                  >
+                    {columnIndex === 0 && descriptor.totalRow?.label ? descriptor.totalRow.label : value ?? '—'}
+                  </td>
+                );
+              })}
+            </tr>
+          </tfoot>
+        )}
+      </table>
+    </div>
+  );
+};
+
+export default ReportTable;

--- a/frontend-app/src/modules/reportes/components/ReportesLayout.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportesLayout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import AdvancedFilters from './AdvancedFilters';
+import type { ReportFilters } from '../types';
+import '../reportes.css';
+
+interface ReportesLayoutProps {
+  filterDescriptors: Array<{ id: keyof ReportFilters; label: string; helper?: string }>;
+  children: React.ReactNode;
+}
+
+const ReportesLayout: React.FC<ReportesLayoutProps> = ({ filterDescriptors, children }) => (
+  <div className="reportes-module">
+    <AdvancedFilters descriptors={filterDescriptors} />
+    <div className="reportes-module__content">{children}</div>
+  </div>
+);
+
+export default ReportesLayout;

--- a/frontend-app/src/modules/reportes/context/ReportesContext.tsx
+++ b/frontend-app/src/modules/reportes/context/ReportesContext.tsx
@@ -1,0 +1,193 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from '@/lib/router/useSearchParams';
+import {
+  buildShareableLink,
+  compareFilters,
+  isFilterCombinationValid,
+  parseFiltersFromSearch,
+  serializeFiltersToSearch,
+} from '../utils/filters';
+import type { ReportCategory, ReportFilters, ReportPreset } from '../types';
+
+interface ReportesContextValue {
+  category: ReportCategory;
+  setCategory: (category: ReportCategory) => void;
+  filters: ReportFilters;
+  updateFilters: (partial: Partial<ReportFilters>) => void;
+  resetFilters: () => void;
+  isValidCombination: boolean;
+  shareableLink: string;
+  presets: ReportPreset[];
+  savePreset: (name: string) => ReportPreset | null;
+  applyPreset: (id: string) => void;
+  deletePreset: (id: string) => void;
+}
+
+const ReportesContext = createContext<ReportesContextValue | undefined>(undefined);
+
+const PRESETS_KEY = 'reportes:presets';
+
+function loadPresets(): ReportPreset[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(PRESETS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => ({
+        id: String(item.id ?? crypto.randomUUID()),
+        name: String(item.name ?? 'Preset sin nombre'),
+        filters: (item.filters ?? {}) as ReportFilters,
+        createdAt: String(item.createdAt ?? new Date().toISOString()),
+      }))
+      .slice(0, 50);
+  } catch (error) {
+    console.error('No se pudieron cargar los presets de reportes', error);
+    return [];
+  }
+}
+
+function persistPresets(presets: ReportPreset[]) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(PRESETS_KEY, JSON.stringify(presets));
+}
+
+interface ProviderProps {
+  initialCategory?: ReportCategory;
+  onCategoryChange?: (category: ReportCategory) => void;
+  children: React.ReactNode;
+}
+
+const defaultFilters: ReportFilters = {};
+
+export const ReportesProvider: React.FC<ProviderProps> = ({
+  initialCategory = 'financieros',
+  onCategoryChange,
+  children,
+}) => {
+  const [category, setCategoryState] = useState<ReportCategory>(initialCategory);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [filters, setFilters] = useState<ReportFilters>(() => parseFiltersFromSearch(searchParams));
+  const [presets, setPresets] = useState<ReportPreset[]>(() => loadPresets());
+  const lastFiltersRef = useRef<ReportFilters>(filters);
+
+  useEffect(() => {
+    setCategoryState(initialCategory);
+  }, [initialCategory]);
+
+  useEffect(() => {
+    setFilters(parseFiltersFromSearch(searchParams));
+  }, [searchParams]);
+
+  const setCategory = useCallback(
+    (next: ReportCategory) => {
+      setCategoryState(next);
+      onCategoryChange?.(next);
+    },
+    [onCategoryChange],
+  );
+
+  const updateFilters = useCallback(
+    (partial: Partial<ReportFilters>) => {
+      setFilters((current) => {
+        const next = { ...current, ...partial };
+        const normalized = parseFiltersFromSearch(serializeFiltersToSearch(next));
+        setSearchParams(serializeFiltersToSearch(normalized), { replace: true });
+        lastFiltersRef.current = normalized;
+        return normalized;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const resetFilters = useCallback(() => {
+    setFilters(defaultFilters);
+    setSearchParams(new URLSearchParams(), { replace: true });
+    lastFiltersRef.current = defaultFilters;
+  }, [setSearchParams]);
+
+  const isValidCombination = useMemo(() => isFilterCombinationValid(filters), [filters]);
+
+  const shareableLink = useMemo(() => buildShareableLink(filters), [filters]);
+
+  const savePreset = useCallback(
+    (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return null;
+      const preset: ReportPreset = {
+        id: crypto.randomUUID(),
+        name: trimmed,
+        filters,
+        createdAt: new Date().toISOString(),
+      };
+      setPresets((current) => {
+        const next = [preset, ...current].slice(0, 50);
+        persistPresets(next);
+        return next;
+      });
+      return preset;
+    },
+    [filters],
+  );
+
+  const applyPreset = useCallback(
+    (id: string) => {
+      const preset = presets.find((item) => item.id === id);
+      if (!preset) return;
+      if (compareFilters(preset.filters, lastFiltersRef.current)) return;
+      const params = serializeFiltersToSearch(preset.filters);
+      setSearchParams(params, { replace: true });
+      setFilters(preset.filters);
+      lastFiltersRef.current = preset.filters;
+    },
+    [presets, setSearchParams],
+  );
+
+  const deletePreset = useCallback((id: string) => {
+    setPresets((current) => {
+      const next = current.filter((item) => item.id !== id);
+      persistPresets(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<ReportesContextValue>(
+    () => ({
+      category,
+      setCategory,
+      filters,
+      updateFilters,
+      resetFilters,
+      isValidCombination,
+      shareableLink,
+      presets,
+      savePreset,
+      applyPreset,
+      deletePreset,
+    }),
+    [
+      category,
+      setCategory,
+      filters,
+      updateFilters,
+      resetFilters,
+      isValidCombination,
+      shareableLink,
+      presets,
+      savePreset,
+      applyPreset,
+      deletePreset,
+    ],
+  );
+
+  return <ReportesContext.Provider value={value}>{children}</ReportesContext.Provider>;
+};
+
+export function useReportesContext(): ReportesContextValue {
+  const context = useContext(ReportesContext);
+  if (!context) {
+    throw new Error('useReportesContext debe utilizarse dentro de ReportesProvider');
+  }
+  return context;
+}

--- a/frontend-app/src/modules/reportes/hooks/useReportExport.ts
+++ b/frontend-app/src/modules/reportes/hooks/useReportExport.ts
@@ -1,0 +1,74 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useQueryClient } from '@/lib/query/QueryClient';
+import type { ExportProgress, ReportFilters, ReportFormat, ReportId } from '../types';
+import { exportReport, logDownload } from '../api/reportesApi';
+import { useReportesContext } from '../context/ReportesContext';
+
+interface UseReportExportResult {
+  progress: ExportProgress;
+  exportAsCsv: () => Promise<void>;
+  exportAsXlsx: () => Promise<void>;
+  reset: () => void;
+}
+
+const initialProgress: ExportProgress = { status: 'idle', percentage: 0 };
+
+export function useReportExport(reportId: ReportId): UseReportExportResult {
+  const queryClient = useQueryClient();
+  const { filters } = useReportesContext();
+  const [progress, setProgress] = useState<ExportProgress>(initialProgress);
+
+  const performExport = useCallback(
+    async (format: Exclude<ReportFormat, 'json'>) => {
+      setProgress({ status: 'preparing', percentage: 10, message: 'Generando archivo…' });
+      try {
+        const result = await exportReport(reportId, filters, format);
+        if (result.status === 'error') {
+          setProgress(result);
+          await logDownload(reportId, filters, format, 'failed', 0);
+          return;
+        }
+
+        setProgress({
+          ...result,
+          status: 'completed',
+          message: result.message ?? 'Descarga lista.',
+          percentage: 100,
+        });
+
+        await logDownload(reportId, filters, format, 'completed', result.rowCount ?? 0);
+
+        if (result.downloadUrl && typeof window !== 'undefined') {
+          window.open(result.downloadUrl, '_blank', 'noopener');
+        }
+      } catch (error) {
+        setProgress({
+          status: 'error',
+          percentage: 100,
+          error: 'No fue posible completar la exportación. Intenta nuevamente.',
+        });
+        await logDownload(reportId, filters, format, 'failed', 0);
+      } finally {
+        queryClient.invalidateQueries(['reportes', 'descargas']);
+      }
+    },
+    [filters, queryClient, reportId],
+  );
+
+  const exportAsCsv = useCallback(() => performExport('csv'), [performExport]);
+  const exportAsXlsx = useCallback(() => performExport('xlsx'), [performExport]);
+
+  const reset = useCallback(() => {
+    setProgress(initialProgress);
+  }, []);
+
+  return useMemo(
+    () => ({
+      progress,
+      exportAsCsv,
+      exportAsXlsx,
+      reset,
+    }),
+    [progress, exportAsCsv, exportAsXlsx, reset],
+  );
+}

--- a/frontend-app/src/modules/reportes/hooks/useReportQuery.ts
+++ b/frontend-app/src/modules/reportes/hooks/useReportQuery.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { useQuery } from '@/lib/query/QueryClient';
+import type { QueryStatus } from '@/lib/query/queryClientCore';
+import type { ReportFilters, ReportId } from '../types';
+import { useReportesContext } from '../context/ReportesContext';
+
+interface UseReportQueryOptions<TData> {
+  reportId: ReportId;
+  queryKeySuffix?: unknown;
+  fetcher: (filters: ReportFilters) => Promise<TData>;
+}
+
+interface UseReportQueryResult<TData> {
+  status: QueryStatus;
+  data: TData | undefined;
+  error: unknown;
+  isFetching: boolean;
+  refetch: () => Promise<TData>;
+}
+
+export function useReportQuery<TData>({
+  reportId,
+  queryKeySuffix,
+  fetcher,
+}: UseReportQueryOptions<TData>): UseReportQueryResult<TData> {
+  const { filters } = useReportesContext();
+  const queryKey = useMemo(() => ['reportes', reportId, filters, queryKeySuffix], [reportId, filters, queryKeySuffix]);
+
+  const query = useQuery<TData>({
+    queryKey,
+    queryFn: () => fetcher(filters),
+  });
+
+  return {
+    status: query.status,
+    data: query.data,
+    error: query.error,
+    isFetching: query.status === 'loading' || query.status === 'idle',
+    refetch: query.refetch,
+  };
+}

--- a/frontend-app/src/modules/reportes/index.tsx
+++ b/frontend-app/src/modules/reportes/index.tsx
@@ -1,0 +1,43 @@
+import React, { Suspense, useMemo } from 'react';
+import ReportesLayout from './components/ReportesLayout';
+import ReportSkeleton from './components/ReportSkeleton';
+import { ReportesProvider } from './context/ReportesContext';
+import type { ReportCategory, ReportFilters } from './types';
+
+const FinancierosPage = React.lazy(() => import('./pages/FinancierosPage'));
+const OperativosPage = React.lazy(() => import('./pages/OperativosPage'));
+const AuditoriaPage = React.lazy(() => import('./pages/AuditoriaPage'));
+
+const categoryComponentMap: Record<ReportCategory, React.ComponentType> = {
+  financieros: FinancierosPage,
+  operativos: OperativosPage,
+  auditoria: AuditoriaPage,
+};
+
+const filterDescriptors: Array<{ id: keyof ReportFilters; label: string; helper?: string }> = [
+  { id: 'periodo', label: 'Periodo (mes)', helper: 'Selecciona el mes de análisis (formato AAAA-MM).' },
+  { id: 'producto', label: 'Producto', helper: 'Filtra por nombre o clave de producto.' },
+  { id: 'centro', label: 'Centro de costos', helper: 'Requiere seleccionar un periodo para habilitarse.' },
+  { id: 'format', label: 'Formato preferido' },
+];
+
+interface ReportesModuleProps {
+  activeCategory: ReportCategory;
+  onCategoryChange?: (category: ReportCategory) => void;
+}
+
+const ReportesModule: React.FC<ReportesModuleProps> = ({ activeCategory, onCategoryChange }) => {
+  const ActiveComponent = useMemo(() => categoryComponentMap[activeCategory], [activeCategory]);
+
+  return (
+    <ReportesProvider initialCategory={activeCategory} onCategoryChange={onCategoryChange}>
+      <ReportesLayout filterDescriptors={filterDescriptors}>
+        <Suspense fallback={<ReportSkeleton />}>
+          <ActiveComponent />
+        </Suspense>
+      </ReportesLayout>
+    </ReportesProvider>
+  );
+};
+
+export default ReportesModule;

--- a/frontend-app/src/modules/reportes/pages/AuditoriaPage.tsx
+++ b/frontend-app/src/modules/reportes/pages/AuditoriaPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReportSection from '../components/ReportSection';
+import DownloadLogTable from '../components/DownloadLogTable';
+import ReportSkeleton from '../components/ReportSkeleton';
+import { useReportQuery } from '../hooks/useReportQuery';
+import { fetchDownloadLog } from '../api/reportesApi';
+
+const AuditoriaPage: React.FC = () => {
+  const downloadLogQuery = useReportQuery({ reportId: 'descargas', fetcher: fetchDownloadLog });
+
+  return (
+    <ReportSection
+      title="Bitácora de descargas"
+      description="Registra cada exportación con filtros utilizados, formato y usuario solicitante."
+    >
+      {downloadLogQuery.status === 'loading' && <ReportSkeleton />}
+      {downloadLogQuery.status === 'error' && (
+        <div role="alert" className="reportes-empty-state">
+          <h4>No fue posible obtener la bitácora</h4>
+          <p>Intenta nuevamente o verifica la configuración de auditoría.</p>
+        </div>
+      )}
+      {downloadLogQuery.data && <DownloadLogTable logs={downloadLogQuery.data} />}
+    </ReportSection>
+  );
+};
+
+export default AuditoriaPage;

--- a/frontend-app/src/modules/reportes/pages/FinancierosPage.tsx
+++ b/frontend-app/src/modules/reportes/pages/FinancierosPage.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import ReportSection from '../components/ReportSection';
+import ReportSummaryCards from '../components/ReportSummaryCards';
+import ReportTable from '../components/ReportTable';
+import ExportToolbar from '../components/ExportToolbar';
+import ReportSkeleton from '../components/ReportSkeleton';
+import ComparisonChart from '../components/ComparisonChart';
+import { useReportQuery } from '../hooks/useReportQuery';
+import { fetchComparativoReport, fetchCostosReport } from '../api/reportesApi';
+
+const FinancierosPage: React.FC = () => {
+  const costosQuery = useReportQuery({ reportId: 'costos', fetcher: fetchCostosReport });
+  const comparativoQuery = useReportQuery({ reportId: 'comparativo', fetcher: fetchComparativoReport });
+
+  const isLoading = costosQuery.status === 'loading';
+  const hasError = costosQuery.status === 'error';
+
+  return (
+    <>
+      <ReportSection
+        title="Costos consolidados"
+        description="Consulta costos, consumos y CIF consolidados con totales y tendencias clave."
+        actions={<ExportToolbar reportId="costos" disabled={hasError} />}
+      >
+        {isLoading && <ReportSkeleton />}
+        {hasError && (
+          <div role="alert" className="reportes-empty-state">
+            <h4>No fue posible cargar la información</h4>
+            <p>Vuelve a intentarlo o ajusta los filtros seleccionados.</p>
+          </div>
+        )}
+        {costosQuery.data && !hasError && (
+          <>
+            <ReportSummaryCards cards={costosQuery.data.cards} />
+            {costosQuery.data.tables.map((table) => (
+              <ReportTable key={table.id} descriptor={table} />
+            ))}
+          </>
+        )}
+      </ReportSection>
+
+      <ReportSection
+        title="Comparativo egresos vs insumos"
+        description="Visualiza la diferencia entre egresos e insumos para validar la consistencia del periodo."
+        actions={<ExportToolbar reportId="comparativo" disabled={comparativoQuery.status === 'error'} />}
+      >
+        {comparativoQuery.status === 'loading' && <ReportSkeleton />}
+        {comparativoQuery.status === 'error' && (
+          <div role="alert" className="reportes-empty-state">
+            <h4>No fue posible obtener el comparativo</h4>
+            <p>Verifica la conexión o intenta con un periodo distinto.</p>
+          </div>
+        )}
+        {comparativoQuery.data && comparativoQuery.data.points.length > 0 && (
+          <ComparisonChart data={comparativoQuery.data.points} insight={comparativoQuery.data.insight} />
+        )}
+      </ReportSection>
+    </>
+  );
+};
+
+export default FinancierosPage;

--- a/frontend-app/src/modules/reportes/pages/OperativosPage.tsx
+++ b/frontend-app/src/modules/reportes/pages/OperativosPage.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import ReportSection from '../components/ReportSection';
+import ReportTable from '../components/ReportTable';
+import ReportSkeleton from '../components/ReportSkeleton';
+import ExportToolbar from '../components/ExportToolbar';
+import { useReportQuery } from '../hooks/useReportQuery';
+import { fetchAsignacionesReport, fetchConsumosReport, fetchManoObraReport } from '../api/reportesApi';
+
+const OperativosPage: React.FC = () => {
+  const consumosQuery = useReportQuery({ reportId: 'consumos', fetcher: fetchConsumosReport });
+  const asignacionesQuery = useReportQuery({ reportId: 'asignaciones', fetcher: fetchAsignacionesReport });
+  const manoObraQuery = useReportQuery({ reportId: 'mano-obra', fetcher: fetchManoObraReport });
+
+  return (
+    <>
+      <ReportSection
+        title="Consumos consolidados"
+        description="Revisa consumos por producto y unidad con totales acumulados."
+        actions={<ExportToolbar reportId="consumos" disabled={consumosQuery.status === 'error'} />}
+      >
+        {consumosQuery.status === 'loading' && <ReportSkeleton />}
+        {consumosQuery.status === 'error' && (
+          <div role="alert" className="reportes-empty-state">
+            <h4>Error al cargar consumos</h4>
+            <p>Intenta nuevamente o ajusta tus filtros.</p>
+          </div>
+        )}
+        {consumosQuery.data && <ReportTable descriptor={consumosQuery.data} />}
+      </ReportSection>
+
+      <ReportSection
+        title="Asignaciones por centro"
+        description="Horas y porcentajes aplicados por actividad y centro de producción."
+        actions={<ExportToolbar reportId="asignaciones" disabled={asignacionesQuery.status === 'error'} />}
+      >
+        {asignacionesQuery.status === 'loading' && <ReportSkeleton />}
+        {asignacionesQuery.status === 'error' && (
+          <div role="alert" className="reportes-empty-state">
+            <h4>No fue posible cargar las asignaciones</h4>
+            <p>Revisa tu conexión o cambia los filtros.</p>
+          </div>
+        )}
+        {asignacionesQuery.data && <ReportTable descriptor={asignacionesQuery.data} />}
+      </ReportSection>
+
+      <ReportSection
+        title="Mano de obra por actividad"
+        description="Detalle de horas y monto asignado por actividad operativa."
+        actions={<ExportToolbar reportId="mano-obra" disabled={manoObraQuery.status === 'error'} />}
+      >
+        {manoObraQuery.status === 'loading' && <ReportSkeleton />}
+        {manoObraQuery.status === 'error' && (
+          <div role="alert" className="reportes-empty-state">
+            <h4>No se pudo recuperar la información de mano de obra</h4>
+            <p>Vuelve a ejecutar la consulta más tarde.</p>
+          </div>
+        )}
+        {manoObraQuery.data && <ReportTable descriptor={manoObraQuery.data} />}
+      </ReportSection>
+    </>
+  );
+};
+
+export default OperativosPage;

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -1,0 +1,252 @@
+.reportes-module {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.5rem;
+  min-height: 100%;
+}
+
+.reportes-module__filters {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 16px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reportes-module__filters h2 {
+  font-size: 1.125rem;
+  margin: 0;
+}
+
+.reportes-module__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.reportes-module__section {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.reportes-module__section h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.reportes-module__section p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #475569;
+}
+
+.reportes-skeleton {
+  display: grid;
+  gap: 1rem;
+}
+
+.reportes-skeleton__card {
+  height: 96px;
+  background: linear-gradient(90deg, rgba(241, 245, 249, 0.7), rgba(226, 232, 240, 0.9), rgba(241, 245, 249, 0.7));
+  border-radius: 16px;
+  animation: reportesPulse 1.5s ease-in-out infinite;
+}
+
+.reportes-skeleton__table {
+  height: 320px;
+  border-radius: 16px;
+  background: linear-gradient(90deg, rgba(226, 232, 240, 0.7), rgba(203, 213, 225, 0.9), rgba(226, 232, 240, 0.7));
+  animation: reportesPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes reportesPulse {
+  0% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
+.reportes-summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.reportes-summary-card {
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: #0f172a;
+  color: #f8fafc;
+  position: relative;
+  overflow: hidden;
+}
+
+.reportes-summary-card--success {
+  background: linear-gradient(135deg, #0f172a, #0d9488);
+}
+
+.reportes-summary-card--warning {
+  background: linear-gradient(135deg, #0f172a, #facc15);
+}
+
+.reportes-summary-card--danger {
+  background: linear-gradient(135deg, #0f172a, #f97316);
+}
+
+.reportes-summary-card__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.reportes-summary-card__value {
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.reportes-summary-card__help {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.reportes-table-wrapper {
+  overflow-x: auto;
+}
+
+.reportes-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.reportes-table thead {
+  background: #f1f5f9;
+  text-align: left;
+}
+
+.reportes-table th,
+.reportes-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.reportes-table tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.reportes-table tfoot td {
+  background: #e2e8f0;
+  font-weight: 600;
+}
+
+.reportes-table__numeric {
+  text-align: right;
+}
+
+.reportes-empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #475569;
+  border: 1px dashed #cbd5f5;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.reportes-empty-state h4 {
+  margin: 0 0 0.5rem;
+}
+
+.reportes-export-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.reportes-export-bar button {
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  border: none;
+  cursor: pointer;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.reportes-export-bar button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reportes-export-bar__status {
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.reportes-presets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reportes-presets__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.reportes-presets__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.3);
+  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+}
+
+.reportes-presets__item button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+}
+
+.reportes-presets__item button:hover {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.reportes-presets__name {
+  font-weight: 600;
+}
+
+.reportes-presets__meta {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+@media (max-width: 1200px) {
+  .reportes-module {
+    grid-template-columns: 1fr;
+  }
+
+  .reportes-module__filters {
+    order: 2;
+  }
+}

--- a/frontend-app/src/modules/reportes/routes.tsx
+++ b/frontend-app/src/modules/reportes/routes.tsx
@@ -1,0 +1,27 @@
+import type { ReportRoute } from './types';
+
+export function buildReportesRoutes(): ReportRoute[] {
+  return [
+    {
+      id: 'financieros',
+      path: 'financieros',
+      title: 'Reportes financieros',
+      description: 'Consolida costos, CIF y comparativos de egresos vs insumos.',
+      permissions: ['reportes.financieros'],
+    },
+    {
+      id: 'operativos',
+      path: 'operativos',
+      title: 'Reportes operativos',
+      description: 'Monitorea consumos, asignaciones y mano de obra diaria.',
+      permissions: ['reportes.operativos'],
+    },
+    {
+      id: 'auditoria',
+      path: 'auditoria',
+      title: 'Auditoría y bitácoras',
+      description: 'Da seguimiento a exportaciones y parámetros utilizados.',
+      permissions: ['reportes.auditoria'],
+    },
+  ];
+}

--- a/frontend-app/src/modules/reportes/types.ts
+++ b/frontend-app/src/modules/reportes/types.ts
@@ -1,0 +1,102 @@
+export type ReportCategory = 'financieros' | 'operativos' | 'auditoria';
+
+export type ReportFormat = 'json' | 'csv' | 'xlsx';
+
+export interface ReportFilters {
+  periodo?: string;
+  producto?: string;
+  centro?: string;
+  format?: ReportFormat;
+}
+
+export type ReportId =
+  | 'costos'
+  | 'comparativo'
+  | 'cif'
+  | 'consumos'
+  | 'asignaciones'
+  | 'mano-obra'
+  | 'descargas';
+
+export interface ReportPreset {
+  id: string;
+  name: string;
+  filters: ReportFilters;
+  createdAt: string;
+}
+
+export interface ReportRoute {
+  id: ReportCategory;
+  path: string;
+  title: string;
+  description: string;
+  permissions: string[];
+}
+
+export interface ReportDescriptor {
+  id: ReportId;
+  title: string;
+  description: string;
+  requiredFilters?: Array<keyof ReportFilters>;
+}
+
+export interface ReportDownloadLog {
+  id: string;
+  reportId: ReportId;
+  filters: ReportFilters;
+  format: ReportFormat;
+  status: 'completed' | 'failed' | 'pending';
+  rowCount: number;
+  createdBy: string;
+  requestedAt: string;
+  completedAt?: string;
+}
+
+export interface BaseTableRow {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface ReportTableDescriptor<Row extends BaseTableRow = BaseTableRow> {
+  id: string;
+  title: string;
+  description: string;
+  columns: Array<{
+    id: keyof Row;
+    label: string;
+    align?: 'left' | 'right' | 'center';
+    isNumeric?: boolean;
+  }>;
+  rows: Row[];
+  subtotalBy?: keyof Row;
+  totalRow?: Partial<Row> & { label?: string };
+  emptyMessage?: string;
+}
+
+export interface ReportSummaryCard {
+  id: string;
+  label: string;
+  value: string;
+  helpText?: string;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+export interface ComparisonPoint {
+  name: string;
+  egresos: number;
+  insumos: number;
+}
+
+export interface ComparisonInsight {
+  differenceLabel: string;
+  consistent: boolean;
+  statusLabel: string;
+}
+
+export interface ExportProgress {
+  status: 'idle' | 'preparing' | 'downloading' | 'completed' | 'error';
+  percentage: number;
+  message?: string;
+  error?: string;
+  downloadUrl?: string;
+  rowCount?: number;
+}

--- a/frontend-app/src/modules/reportes/utils/filters.ts
+++ b/frontend-app/src/modules/reportes/utils/filters.ts
@@ -1,0 +1,77 @@
+import type { ReportFilters, ReportFormat } from '../types';
+
+const PERIOD_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+const DATE_REGEX = /^\d{4}-(0[1-9]|1[0-2])-01$/;
+
+export function normalizePeriodo(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  if (DATE_REGEX.test(value)) return value;
+  if (PERIOD_REGEX.test(value)) {
+    return `${value}-01`;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  const month = String(parsed.getMonth() + 1).padStart(2, '0');
+  return `${parsed.getFullYear()}-${month}-01`;
+}
+
+export function normalizeProducto(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function normalizeCentro(value?: string | null): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const trimmed = String(value).trim();
+  if (trimmed === '') return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? String(parsed) : undefined;
+}
+
+export function normalizeFormat(value?: string | null): ReportFormat | undefined {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  if (normalized === 'csv' || normalized === 'xlsx' || normalized === 'json') {
+    return normalized;
+  }
+  return undefined;
+}
+
+export function parseFiltersFromSearch(params: URLSearchParams): ReportFilters {
+  return {
+    periodo: normalizePeriodo(params.get('periodo')),
+    producto: normalizeProducto(params.get('producto')),
+    centro: normalizeCentro(params.get('centro')),
+    format: normalizeFormat(params.get('format')),
+  };
+}
+
+export function serializeFiltersToSearch(filters: ReportFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.periodo) params.set('periodo', filters.periodo);
+  if (filters.producto) params.set('producto', filters.producto);
+  if (filters.centro) params.set('centro', filters.centro);
+  if (filters.format) params.set('format', filters.format);
+  return params;
+}
+
+export function isFilterCombinationValid(filters: ReportFilters): boolean {
+  if (filters.centro && !filters.periodo) {
+    return false;
+  }
+  return true;
+}
+
+export function buildShareableLink(filters: ReportFilters): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  const params = serializeFiltersToSearch(filters);
+  const query = params.toString();
+  return `${window.location.origin}${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+}
+
+export function compareFilters(a: ReportFilters, b: ReportFilters): boolean {
+  return a.periodo === b.periodo && a.producto === b.producto && a.centro === b.centro && a.format === b.format;
+}

--- a/frontend-app/src/modules/reportes/utils/normalizers.ts
+++ b/frontend-app/src/modules/reportes/utils/normalizers.ts
@@ -1,0 +1,295 @@
+import { formatCurrency, formatPercentage } from '@/lib/formatters';
+import type {
+  ComparisonInsight,
+  ComparisonPoint,
+  ReportDownloadLog,
+  ReportFilters,
+  ReportSummaryCard,
+  ReportTableDescriptor,
+} from '../types';
+
+interface CostosResponse {
+  costos?: Array<{ centro?: string | number; monto?: number }>;
+  consumos?: Array<{ producto?: string; cantidad?: number }>;
+  cif?: Array<{ producto?: string; monto?: number }>;
+  control?: {
+    totalEgresos?: number;
+    totalInsumos?: number;
+    consistente?: boolean;
+    diferencia?: number;
+  };
+}
+
+interface ComparativoResponse {
+  totalEgresos?: number;
+  totalInsumos?: number;
+  consistente?: boolean;
+  diferencia?: number;
+}
+
+interface CifResponseItem {
+  producto?: string;
+  periodo?: string;
+  monto?: number;
+}
+
+interface ConsumosResponseItem {
+  producto?: string;
+  unidad?: string;
+  cantidad?: number;
+  monto?: number;
+}
+
+interface AsignacionesResponseItem {
+  centro?: string;
+  actividad?: string;
+  horas?: number;
+  porcentaje?: number;
+}
+
+interface ManoObraResponseItem {
+  actividad?: string;
+  descripcion?: string;
+  horas?: number;
+  monto?: number;
+}
+
+export function normalizeCostosResponse(response: unknown): Required<CostosResponse> {
+  const defaultControl = {
+    totalEgresos: 0,
+    totalInsumos: 0,
+    consistente: false,
+    diferencia: 0,
+  };
+  if (!response || typeof response !== 'object') {
+    return { costos: [], consumos: [], cif: [], control: defaultControl };
+  }
+  const data = response as Record<string, unknown>;
+  const costos = Array.isArray(data.costos) ? data.costos : [];
+  const consumos = Array.isArray(data.consumos) ? data.consumos : [];
+  const cif = Array.isArray(data.cif) ? data.cif : [];
+  const control = data.control && typeof data.control === 'object' ? data.control : {};
+  return {
+    costos: costos.map((item) => ({
+      centro: String((item as { centro?: string | number }).centro ?? '—'),
+      monto: Number((item as { monto?: number }).monto ?? 0),
+    })),
+    consumos: consumos.map((item) => ({
+      producto: String((item as { producto?: string }).producto ?? '—'),
+      cantidad: Number((item as { cantidad?: number }).cantidad ?? 0),
+    })),
+    cif: cif.map((item) => ({
+      producto: String((item as { producto?: string }).producto ?? '—'),
+      monto: Number((item as { monto?: number }).monto ?? 0),
+    })),
+    control: {
+      totalEgresos: Number((control as { totalEgresos?: number }).totalEgresos ?? 0),
+      totalInsumos: Number((control as { totalInsumos?: number }).totalInsumos ?? 0),
+      consistente: Boolean((control as { consistente?: boolean }).consistente ?? false),
+      diferencia: Number((control as { diferencia?: number }).diferencia ?? 0),
+    },
+  };
+}
+
+export function buildCostosSummaryCards(response: Required<CostosResponse>): ReportSummaryCard[] {
+  const { totalEgresos, totalInsumos, consistente, diferencia } = response.control;
+  const cards: ReportSummaryCard[] = [
+    {
+      id: 'total-egresos',
+      label: 'Total egresos',
+      value: formatCurrency(totalEgresos),
+    },
+    {
+      id: 'total-insumos',
+      label: 'Total insumos',
+      value: formatCurrency(totalInsumos),
+    },
+    {
+      id: 'diferencia',
+      label: 'Diferencia',
+      value: formatCurrency(diferencia),
+      tone: Math.abs(diferencia) > totalInsumos * 0.05 ? 'warning' : 'default',
+      helpText: 'Control de consistencia entre egresos e insumos.',
+    },
+  ];
+  cards.push({
+    id: 'consistencia',
+    label: 'Consistencia',
+    value: consistente ? '✔ Consistente' : '⚠ Revisar',
+    tone: consistente ? 'success' : 'danger',
+    helpText: consistente
+      ? 'Los totales cuadran dentro del margen aceptable.'
+      : 'Existe una desviación entre egresos e insumos.',
+  });
+  return cards;
+}
+
+export function normalizeComparativoResponse(response: unknown): ComparisonPoint[] {
+  const data = (response && typeof response === 'object' ? response : {}) as ComparativoResponse;
+  const egresos = Number(data.totalEgresos ?? 0);
+  const insumos = Number(data.totalInsumos ?? 0);
+  return [
+    { name: 'Consolidado actual', egresos, insumos },
+  ];
+}
+
+export function buildComparisonInsight(response: unknown): ComparisonInsight {
+  const data = (response && typeof response === 'object' ? response : {}) as ComparativoResponse;
+  const difference = Number(data.diferencia ?? 0);
+  const egresos = Number(data.totalEgresos ?? 0);
+  const insumos = Number(data.totalInsumos ?? 0);
+  const consistent = Boolean(data.consistente ?? false);
+  const label = formatCurrency(difference);
+  const statusLabel = consistent
+    ? 'Los totales coinciden con el margen permitido.'
+    : 'Revisar ajustes de costos indirectos.';
+  return {
+    differenceLabel: `${label} · Variación ${formatPercentage(
+      egresos === 0 ? 0 : difference / egresos,
+    )}`,
+    consistent,
+    statusLabel,
+  };
+}
+
+export function normalizeCifResponse(response: unknown): ReportTableDescriptor<{ producto: string; periodo: string; monto: string }> {
+  const items = Array.isArray(response) ? response : Array.isArray((response as { data?: unknown }).data) ? (response as { data?: unknown[] }).data ?? [] : [];
+  const rows = (items as CifResponseItem[]).map((item) => ({
+    producto: String(item.producto ?? '—'),
+    periodo: item.periodo ? item.periodo.slice(0, 7) : '—',
+    monto: formatCurrency(Number(item.monto ?? 0)),
+  }));
+  return {
+    id: 'cif',
+    title: 'CIF por producto',
+    description: 'Agregación de costos indirectos aplicados por producto y periodo.',
+    columns: [
+      { id: 'producto', label: 'Producto' },
+      { id: 'periodo', label: 'Periodo' },
+      { id: 'monto', label: 'Monto', align: 'right', isNumeric: true },
+    ],
+    rows,
+    emptyMessage: 'No hay datos de CIF para los filtros aplicados.',
+  };
+}
+
+export function normalizeConsumosResponse(response: unknown): ReportTableDescriptor<{
+  producto: string;
+  unidad: string;
+  cantidad: string;
+  monto: string;
+}> {
+  const items = Array.isArray(response)
+    ? response
+    : Array.isArray((response as { items?: unknown[] }).items)
+      ? (response as { items?: unknown[] }).items ?? []
+      : [];
+  const rows = (items as ConsumosResponseItem[]).map((item) => ({
+    producto: String(item.producto ?? '—'),
+    unidad: String(item.unidad ?? '—'),
+    cantidad: new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+      Number(item.cantidad ?? 0),
+    ),
+    monto: formatCurrency(Number(item.monto ?? 0)),
+  }));
+  return {
+    id: 'consumos',
+    title: 'Consumos consolidados',
+    description: 'Totales por producto y unidad consumida.',
+    columns: [
+      { id: 'producto', label: 'Producto' },
+      { id: 'unidad', label: 'Unidad' },
+      { id: 'cantidad', label: 'Cantidad', align: 'right', isNumeric: true },
+      { id: 'monto', label: 'Monto', align: 'right', isNumeric: true },
+    ],
+    rows,
+    emptyMessage: 'No se encontraron consumos para los filtros seleccionados.',
+  };
+}
+
+export function normalizeAsignacionesResponse(response: unknown): ReportTableDescriptor<{
+  centro: string;
+  actividad: string;
+  horas: string;
+  porcentaje: string;
+}> {
+  const items = Array.isArray(response)
+    ? response
+    : Array.isArray((response as { data?: unknown[] }).data)
+      ? (response as { data?: unknown[] }).data ?? []
+      : [];
+  const rows = (items as AsignacionesResponseItem[]).map((item) => ({
+    centro: String(item.centro ?? '—'),
+    actividad: String(item.actividad ?? '—'),
+    horas: new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+      Number(item.horas ?? 0),
+    ),
+    porcentaje: formatPercentage(Number(item.porcentaje ?? 0)),
+  }));
+  return {
+    id: 'asignaciones',
+    title: 'Asignaciones por centro',
+    description: 'Horas y porcentaje aplicado por actividad.',
+    columns: [
+      { id: 'centro', label: 'Centro' },
+      { id: 'actividad', label: 'Actividad' },
+      { id: 'horas', label: 'Horas', align: 'right', isNumeric: true },
+      { id: 'porcentaje', label: '% asignado', align: 'right' },
+    ],
+    rows,
+    emptyMessage: 'No existen asignaciones con los filtros configurados.',
+  };
+}
+
+export function normalizeManoObraResponse(response: unknown): ReportTableDescriptor<{
+  actividad: string;
+  descripcion: string;
+  horas: string;
+  monto: string;
+}> {
+  const items = Array.isArray(response)
+    ? response
+    : Array.isArray((response as { items?: unknown[] }).items)
+      ? (response as { items?: unknown[] }).items ?? []
+      : [];
+  const rows = (items as ManoObraResponseItem[]).map((item) => ({
+    actividad: String(item.actividad ?? '—'),
+    descripcion: String(item.descripcion ?? '—'),
+    horas: new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+      Number(item.horas ?? 0),
+    ),
+    monto: formatCurrency(Number(item.monto ?? 0)),
+  }));
+  return {
+    id: 'mano-obra',
+    title: 'Mano de obra por actividad',
+    description: 'Horas y monto asignado a cada actividad productiva.',
+    columns: [
+      { id: 'actividad', label: 'Actividad' },
+      { id: 'descripcion', label: 'Descripción' },
+      { id: 'horas', label: 'Horas', align: 'right', isNumeric: true },
+      { id: 'monto', label: 'Monto', align: 'right', isNumeric: true },
+    ],
+    rows,
+    emptyMessage: 'Sin información de mano de obra para los criterios actuales.',
+  };
+}
+
+export function normalizeDownloadLog(response: unknown): ReportDownloadLog[] {
+  const items = Array.isArray(response)
+    ? response
+    : Array.isArray((response as { items?: unknown[] }).items)
+      ? (response as { items?: unknown[] }).items ?? []
+      : [];
+  return (items as Record<string, unknown>[]).map((item, index) => ({
+    id: String(item.id ?? `log-${index}`),
+    reportId: String(item.reportId ?? item.reporte ?? 'costos') as ReportDownloadLog['reportId'],
+    filters: (item.filters as ReportFilters) ?? {},
+    format: String(item.format ?? 'csv') as ReportDownloadLog['format'],
+    status: (item.status as ReportDownloadLog['status']) ?? 'completed',
+    rowCount: Number(item.rowCount ?? item.totalRows ?? 0),
+    createdBy: String(item.createdBy ?? item.usuario ?? 'sistema'),
+    requestedAt: String(item.requestedAt ?? item.createdAt ?? new Date().toISOString()),
+    completedAt: item.completedAt ? String(item.completedAt) : undefined,
+  }));
+}

--- a/frontend-description/reportes-guia-rapida.md
+++ b/frontend-description/reportes-guia-rapida.md
@@ -1,0 +1,63 @@
+# Guía rápida de reportes y analítica
+
+Esta guía complementa el módulo de reportes del frontend. Resume los indicadores clave, los filtros sugeridos y la forma de interpretar cada visualización disponible.
+
+## Reportes financieros
+
+### Costos consolidados (`GET /api/reportes/costos`)
+- **Qué muestra:** Totales de costos por centro, consumos por producto y CIF agregados.
+- **Filtros recomendados:** `periodo` (obligatorio para comparativos), `centro` cuando se requiere auditar un área específica.
+- **KPIs:**
+  - *Total egresos* y *total insumos* deben mantenerse alineados; la tarjeta de consistencia refleja el estado (`consistente`).
+  - *Diferencia* muestra desviaciones absolutas y destaca variaciones mayores al 5 %.
+- **Uso sugerido:** Antes de cerrar el mes valida que la tarjeta de consistencia permanezca en verde. Si aparecen alertas, navega a Costos → Gastos para identificar movimientos anómalos.
+
+### Comparativo egresos vs insumos (`GET /api/reportes/comparativo`)
+- **Qué muestra:** Diferencia entre egresos e insumos del periodo en un gráfico de barras.
+- **Interpretación:**
+  - *Diferencia* se expresa en moneda y porcentaje sobre egresos.
+  - El estatus indica si la diferencia está dentro del margen permitido por control interno.
+- **Buenas prácticas:** Comparte el deep-link con el área financiera cuando detectes una desviación para que confirmen ajustes de CIF.
+
+### CIF por producto (`GET /api/reportes/cif`)
+- **Qué muestra:** Monto de costos indirectos aplicados a cada producto por periodo.
+- **Notas:** Ideal para revisar tendencias de productos críticos; exporta a Excel para cruzar con presupuestos.
+
+## Reportes operativos
+
+### Consumos consolidados (`GET /api/reportes/consumos`)
+- **Descripción:** Tabla con cantidades y montos por producto/unidad.
+- **Indicadores:** Cantidades mostradas con dos decimales para detectar variaciones ligeras.
+- **Recomendación:** Usa `producto` y `periodo` para revisar lotes específicos cuando surgen sobrantes.
+
+### Asignaciones por centro (`GET /api/reportes/asignaciones`)
+- **Descripción:** Horas y porcentajes distribuidos por centro y actividad.
+- **Interpretación:**
+  - Las columnas de porcentaje permiten validar si la distribución respeta las reglas de `frontend-description/asignaciones.md`.
+  - Si se detectan porcentajes fuera del rango esperado, revisar la bitácora de asignaciones.
+
+### Mano de obra (`GET /api/reportes/mano-obra`)
+- **Descripción:** Horas y monto asignado por actividad de producción.
+- **Uso recomendado:** Exporta cuando Recursos Humanos solicite conciliaciones con nómina; comparte el deep-link junto a los filtros aplicados.
+
+## Auditoría y descargas
+
+### Bitácora de exportaciones (`GET /api/reportes/descargas`)
+- **Qué registra:** Reporte descargado, formato, filtros, usuario y estatus de la exportación.
+- **KPIs:** Número de descargas exitosas y fallidas por día.
+- **Buenas prácticas:**
+  - Mantén la bitácora visible al momento de generar reportes para documentar quién compartió cada archivo.
+  - Si hay descargas fallidas consecutivas, revisa el límite de filas (50 000) o ajusta filtros.
+
+## Accesibilidad y rendimiento
+- Todos los gráficos incluyen descripción textual y colores con contraste AA (paleta azul turquesa).
+- Las tablas usan filas de subtotal y estado vacío accesible con `role="status"`.
+- Los loaders skeleton reducen cambios bruscos mientras se obtienen datos.
+- Comparte vistas copiando el enlace desde el panel de filtros; las combinaciones se almacenan como presets reutilizables.
+
+## Flujo recomendado para usuarios finales
+1. Selecciona el **periodo** y, de ser necesario, `producto` o `centro`.
+2. Verifica que la alerta de filtros indique una combinación válida.
+3. Revisa tarjetas y tablas; si detectas anomalías, ajusta filtros.
+4. Utiliza la barra de exportación para generar CSV/Excel y confirma en la bitácora que la descarga se registró.
+5. Guarda un preset con los filtros críticos para reutilizarlos en el próximo cierre.


### PR DESCRIPTION
## Summary
- add a reporting domain with lazy-loaded financial, operational, and audit views wired into the shell navigation
- implement advanced filters with URL persistence, export logging, and visualisations for KPIs
- document the available reports and KPIs in a quick reference guide

## Testing
- not run (dependencies unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e70fbceb788330b39c592cffea39c5