### PR TITLE
Refresh layout spacing and palette

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -1,57 +1,63 @@
 :root {
   color-scheme: light;
   --font-family-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --color-surface: #f4faf6;
+  --color-surface: #f2f7f4;
   --color-surface-alt: #ffffff;
-  --color-surface-muted: #e2f2e9;
-  --color-outline: #d6e4dc;
-  --color-outline-strong: #bfd3c8;
-  --color-text-primary: #0f1f17;
-  --color-text-secondary: #476556;
-  --color-primary: #0f6d44;
-  --color-primary-variant: #1a8c5f;
-  --color-primary-soft: #d9efe4;
+  --color-surface-muted: #e5f1eb;
+  --color-outline: #cbded2;
+  --color-outline-strong: #b4d0c0;
+  --color-text-primary: #0f2419;
+  --color-text-secondary: #4a6b59;
+  --color-primary: #2f7a4d;
+  --color-primary-variant: #3fa369;
+  --color-primary-soft: #d7ede2;
   --color-on-primary: #ffffff;
-  --color-on-primary-container: #06311e;
-  --color-navbar-bg: rgba(255, 255, 255, 0.92);
-  --color-navbar-text: #0c1a14;
-  --color-navbar-subtext: #4c6b5b;
-  --color-navbar-accent: #0b5534;
+  --color-on-primary-container: #0c3a23;
+  --color-primary-rgb: 47, 122, 77;
+  --color-primary-variant-rgb: 63, 163, 105;
+  --color-navbar-bg: rgba(255, 255, 255, 0.94);
+  --color-navbar-text: #143c26;
+  --color-navbar-subtext: #527565;
+  --color-navbar-accent: #226f46;
   --color-danger: #ef4444;
   --color-danger-hover: #dc2626;
-  --shadow-level-1: 0 24px 50px rgba(15, 23, 42, 0.08);
-  --shadow-level-2: 0 32px 80px rgba(15, 23, 42, 0.14);
-  --shadow-border: 0 0 0 1px rgba(15, 23, 42, 0.04);
-  --gradient-app: radial-gradient(circle at top left, rgba(15, 109, 68, 0.18), transparent 45%),
-    radial-gradient(circle at 20% 120%, rgba(16, 185, 129, 0.12), transparent 40%),
-    linear-gradient(180deg, #f6fbf8 0%, #e3f4eb 100%);
+  --shadow-level-1: 0 24px 50px rgba(17, 52, 35, 0.08);
+  --shadow-level-2: 0 32px 80px rgba(14, 42, 28, 0.14);
+  --shadow-border: 0 0 0 1px rgba(20, 83, 45, 0.06);
+  --app-shell-padding: clamp(16px, 4vw, 28px);
+  --gradient-app: radial-gradient(circle at top left, rgba(47, 122, 77, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(98, 181, 131, 0.12), transparent 48%),
+    linear-gradient(180deg, #f5fbf7 0%, #e3f3ea 100%);
 }
 
 [data-theme='dark'] {
   color-scheme: dark;
-  --color-surface: #061712;
-  --color-surface-alt: #082119;
-  --color-surface-muted: #0d2c21;
-  --color-outline: rgba(94, 152, 126, 0.22);
-  --color-outline-strong: rgba(94, 152, 126, 0.36);
-  --color-text-primary: #d9f2e6;
-  --color-text-secondary: #7cb59a;
-  --color-primary: #1a8c5f;
-  --color-primary-variant: #34c88a;
-  --color-primary-soft: rgba(52, 200, 138, 0.18);
-  --color-on-primary: #f1fdf6;
-  --color-on-primary-container: #0a3a25;
-  --color-navbar-bg: rgba(4, 18, 14, 0.9);
-  --color-navbar-text: #f1fdf6;
-  --color-navbar-subtext: #8bd3b0;
-  --color-navbar-accent: #4adea5;
+  --color-surface: #061611;
+  --color-surface-alt: #0b2219;
+  --color-surface-muted: #123327;
+  --color-outline: rgba(86, 140, 111, 0.28);
+  --color-outline-strong: rgba(86, 140, 111, 0.42);
+  --color-text-primary: #d6f1e5;
+  --color-text-secondary: #8ecbaa;
+  --color-primary: #3aa76d;
+  --color-primary-variant: #5bc48a;
+  --color-primary-soft: rgba(74, 181, 120, 0.22);
+  --color-on-primary: #ffffff;
+  --color-on-primary-container: #0f3d28;
+  --color-primary-rgb: 58, 167, 109;
+  --color-primary-variant-rgb: 91, 196, 138;
+  --color-navbar-bg: rgba(5, 20, 16, 0.92);
+  --color-navbar-text: #e6f7ed;
+  --color-navbar-subtext: #90d7b2;
+  --color-navbar-accent: #6ce6a4;
   --color-danger: #f87171;
   --color-danger-hover: #ef4444;
-  --shadow-level-1: 0 28px 60px rgba(1, 12, 9, 0.55);
-  --shadow-level-2: 0 40px 90px rgba(1, 12, 9, 0.7);
-  --shadow-border: 0 0 0 1px rgba(90, 149, 122, 0.16);
-  --gradient-app: radial-gradient(circle at top left, rgba(31, 154, 104, 0.2), transparent 45%),
-    radial-gradient(circle at 80% 0%, rgba(6, 95, 70, 0.18), transparent 55%),
+  --shadow-level-1: 0 28px 60px rgba(0, 18, 12, 0.55);
+  --shadow-level-2: 0 40px 90px rgba(0, 18, 12, 0.7);
+  --shadow-border: 0 0 0 1px rgba(66, 133, 102, 0.22);
+  --app-shell-padding: clamp(14px, 4vw, 24px);
+  --gradient-app: radial-gradient(circle at top left, rgba(58, 167, 109, 0.22), transparent 48%),
+    radial-gradient(circle at 80% 0%, rgba(25, 106, 74, 0.22), transparent 55%),
     linear-gradient(180deg, #051712 0%, #0b241c 100%);
 }
 
@@ -75,7 +81,7 @@ button {
   font-size: 0.95rem;
   line-height: 1.2;
   border-radius: 12px;
-  border: 1px solid rgba(15, 109, 68, 0.18);
+  border: 1px solid rgba(var(--color-primary-rgb), 0.18);
   background: var(--color-surface-alt);
   color: var(--color-text-primary);
   padding: 10px 18px;
@@ -91,13 +97,13 @@ button {
 
 button:hover:not(:disabled) {
   background: var(--color-primary-soft);
-  border-color: rgba(26, 140, 95, 0.45);
+  border-color: rgba(var(--color-primary-variant-rgb), 0.45);
   color: var(--color-primary-variant);
   transform: translateY(-1px);
 }
 
 button:focus-visible {
-  outline: 2px solid rgba(26, 140, 95, 0.45);
+  outline: 2px solid rgba(var(--color-primary-variant-rgb), 0.45);
   outline-offset: 2px;
 }
 
@@ -112,7 +118,7 @@ button.primary {
   background: var(--color-primary);
   border-color: transparent;
   color: var(--color-on-primary);
-  box-shadow: 0 16px 32px rgba(15, 109, 68, 0.28);
+  box-shadow: 0 16px 32px rgba(var(--color-primary-rgb), 0.28);
 }
 
 button.primary:hover:not(:disabled) {
@@ -124,13 +130,13 @@ button.primary:hover:not(:disabled) {
 button.secondary {
   background: transparent;
   color: var(--color-primary);
-  border-color: rgba(26, 140, 95, 0.35);
+  border-color: rgba(var(--color-primary-rgb), 0.32);
   box-shadow: none;
 }
 
 button.secondary:hover:not(:disabled) {
-  background: rgba(26, 140, 95, 0.14);
-  border-color: rgba(26, 140, 95, 0.5);
+  background: rgba(var(--color-primary-variant-rgb), 0.14);
+  border-color: rgba(var(--color-primary-variant-rgb), 0.42);
 }
 
 button.ghost {
@@ -329,13 +335,13 @@ button.small {
 
 .app-navbar__toggle:hover {
   background: var(--color-primary-soft);
-  border-color: rgba(26, 140, 95, 0.4);
+  border-color: rgba(var(--color-primary-variant-rgb), 0.38);
   color: var(--color-navbar-accent);
   transform: translateY(-1px);
 }
 
 .app-navbar__toggle:focus-visible {
-  outline: 2px solid rgba(26, 140, 95, 0.6);
+  outline: 2px solid rgba(var(--color-primary-variant-rgb), 0.6);
   outline-offset: 2px;
 }
 
@@ -374,7 +380,7 @@ button.small {
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-variant) 100%);
   border-color: transparent;
   color: var(--color-on-primary);
-  box-shadow: 0 14px 28px rgba(15, 109, 68, 0.28);
+  box-shadow: 0 14px 28px rgba(var(--color-primary-rgb), 0.28);
 }
 
 .app-navbar__brand {
@@ -392,7 +398,7 @@ button.small {
   font-size: 1.5rem;
   background: var(--color-primary-soft);
   color: var(--color-primary-variant);
-  border: 1px solid rgba(26, 140, 95, 0.28);
+  border: 1px solid rgba(var(--color-primary-variant-rgb), 0.28);
   box-shadow: var(--shadow-border);
 }
 
@@ -408,7 +414,7 @@ button.small {
   letter-spacing: 0.12em;
   font-size: 0.7rem;
   font-weight: 600;
-  color: rgba(11, 85, 52, 0.7);
+  color: rgba(var(--color-primary-rgb), 0.72);
 }
 
 .app-navbar__title {
@@ -450,7 +456,7 @@ button.small {
 }
 
 .app-navbar__domain-button:hover {
-  background: rgba(26, 140, 95, 0.12);
+  background: rgba(var(--color-primary-variant-rgb), 0.14);
   color: var(--color-navbar-accent);
   transform: translateY(-1px);
 }
@@ -459,11 +465,11 @@ button.small {
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-variant) 100%);
   border-color: transparent;
   color: var(--color-on-primary);
-  box-shadow: 0 18px 34px rgba(15, 109, 68, 0.25);
+  box-shadow: 0 18px 34px rgba(var(--color-primary-rgb), 0.24);
 }
 
 .app-navbar__domain-button:focus-visible {
-  outline: 2px solid rgba(26, 140, 95, 0.75);
+  outline: 2px solid rgba(var(--color-primary-rgb), 0.75);
   outline-offset: 2px;
 }
 
@@ -476,7 +482,7 @@ button.small {
 }
 
 .app-navbar__action {
-  border: 1px solid rgba(26, 140, 95, 0.18);
+  border: 1px solid rgba(var(--color-primary-rgb), 0.18);
   border-radius: 12px;
   padding: 10px 18px;
   font-weight: 600;
@@ -490,7 +496,7 @@ button.small {
 
 .app-navbar__action:hover {
   background: var(--color-primary-soft);
-  border-color: rgba(26, 140, 95, 0.5);
+  border-color: rgba(var(--color-primary-variant-rgb), 0.5);
   color: var(--color-navbar-accent);
   transform: translateY(-1px);
 }
@@ -499,7 +505,7 @@ button.small {
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-variant) 100%);
   border-color: transparent;
   color: var(--color-on-primary);
-  box-shadow: 0 18px 34px rgba(15, 109, 68, 0.25);
+  box-shadow: 0 18px 34px rgba(var(--color-primary-rgb), 0.24);
 }
 
 .app-navbar__action--primary:hover {
@@ -519,7 +525,7 @@ button.small {
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-variant) 100%);
   border-color: transparent;
   color: var(--color-on-primary);
-  box-shadow: 0 18px 34px rgba(15, 109, 68, 0.25);
+  box-shadow: 0 18px 34px rgba(var(--color-primary-rgb), 0.24);
 }
 
 .app-navbar__theme-toggle[data-theme='dark']:hover,
@@ -550,16 +556,16 @@ button.small {
   width: 100%;
   max-width: 1280px;
   margin: 0 auto;
-  padding: 24px 28px 60px;
+  padding: calc(var(--app-shell-padding) - 4px) var(--app-shell-padding) 60px;
 }
 
 .app-layout {
   width: 100%;
   display: grid;
-  grid-template-columns: 300px minmax(0, 1fr);
+  grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
   grid-template-areas: 'sidebar main';
   gap: 24px 28px;
-  align-items: stretch;
+  align-items: start;
 }
 
 .app-sidebar {
@@ -634,21 +640,21 @@ button.small {
 }
 
 .app-sidebar__toggle {
-  border: 1px solid rgba(26, 140, 95, 0.25);
-  background: rgba(26, 140, 95, 0.12);
+  border: 1px solid rgba(var(--color-primary-variant-rgb), 0.25);
+  background: rgba(var(--color-primary-variant-rgb), 0.12);
   color: var(--color-primary-variant);
   box-shadow: var(--shadow-border);
 }
 
 .app-sidebar__toggle:hover {
-  background: rgba(26, 140, 95, 0.18);
-  border-color: rgba(26, 140, 95, 0.35);
+  background: rgba(var(--color-primary-variant-rgb), 0.18);
+  border-color: rgba(var(--color-primary-variant-rgb), 0.32);
   color: var(--color-primary);
   transform: translateY(-1px);
 }
 
 .app-sidebar__toggle:focus-visible {
-  outline: 2px solid rgba(26, 140, 95, 0.45);
+  outline: 2px solid rgba(var(--color-primary-variant-rgb), 0.45);
   outline-offset: 2px;
 }
 
@@ -656,7 +662,7 @@ button.small {
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-variant) 100%);
   border-color: transparent;
   color: var(--color-on-primary);
-  box-shadow: 0 16px 30px rgba(15, 109, 68, 0.24);
+  box-shadow: 0 16px 30px rgba(var(--color-primary-rgb), 0.26);
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__content {
@@ -697,13 +703,13 @@ button.small {
 }
 
 .app-sidebar__nav-item[data-active='true'] {
-  background: rgba(26, 140, 95, 0.18);
+  background: rgba(var(--color-primary-variant-rgb), 0.18);
   color: var(--color-primary-variant);
   box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
 }
 
 .app-sidebar__nav-item[data-active='true'] .app-sidebar__nav-icon {
-  background: rgba(26, 140, 95, 0.22);
+  background: rgba(var(--color-primary-variant-rgb), 0.22);
   color: var(--color-on-primary-container);
 }
 
@@ -713,7 +719,7 @@ button.small {
   border-radius: 12px;
   display: grid;
   place-items: center;
-  background: rgba(26, 140, 95, 0.12);
+  background: rgba(var(--color-primary-variant-rgb), 0.12);
   color: var(--color-primary-variant);
   flex-shrink: 0;
 }
@@ -750,7 +756,7 @@ button.small {
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__nav-icon {
-  background: rgba(26, 140, 95, 0.18);
+  background: rgba(var(--color-primary-variant-rgb), 0.18);
 }
 
 .app-sidebar__section {
@@ -760,8 +766,8 @@ button.small {
 }
 
 .app-sidebar__section.is-open {
-  border-color: rgba(26, 140, 95, 0.28);
-  background: rgba(26, 140, 95, 0.08);
+  border-color: rgba(var(--color-primary-variant-rgb), 0.28);
+  background: rgba(var(--color-primary-variant-rgb), 0.1);
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__section {
@@ -864,23 +870,22 @@ button.small {
 
 @media (min-width: 1024px) {
   .app-shell__content {
-    padding-right: 28px;
-    padding-left: 0;
+    padding-inline: calc(var(--app-shell-padding) + 4px);
   }
 
   .app-layout {
-    padding-left: 28px;
+    padding-left: 0;
   }
 
   .app-sidebar:not([data-compact='true']) {
-    margin-left: -28px;
-    border-radius: 0 20px 20px 0;
+    margin-left: 0;
+    border-radius: 20px;
   }
 }
 
 @media (max-width: 1023px) {
   .app-shell__content {
-    padding: 28px 24px 56px;
+    padding: calc(var(--app-shell-padding) + 8px) clamp(18px, 6vw, 24px) 56px;
   }
 
   .app-layout {


### PR DESCRIPTION
## Summary
- refresh the light and dark theme palettes with cohesive green scales and RGB helpers
- update button, navbar, and sidebar treatments to leverage the new variables and shadows
- tune the shell padding and grid so the sidebar and main content align under the header

## Testing
- npm install *(fails: 403 Forbidden while fetching recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68e729f5e6f88330ae19030579b842f0