### PR TITLE
Restyle sidebar navigation to mimic Material drawer

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -473,13 +473,13 @@ button.small {
 }
 
 .app-sidebar {
-  border: 1px solid var(--color-outline);
-  background: var(--color-surface-alt);
-  border-radius: 20px;
-  box-shadow: var(--shadow-level-1);
+  border-right: 1px solid rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+  border-radius: 0;
+  box-shadow: none;
   display: flex;
   flex-direction: column;
-  width: 320px;
+  width: 280px;
   transition: width 0.25s ease, transform 0.3s ease;
   grid-area: sidebar;
   position: relative;
@@ -492,12 +492,13 @@ button.small {
 
 .app-sidebar[data-compact='true'] {
   position: fixed;
-  top: 24px;
+  top: 0;
   left: 0;
-  bottom: 24px;
+  bottom: 0;
   transform: translateX(-120%);
   width: min(320px, 100%);
   z-index: 20;
+  box-shadow: var(--shadow-level-2);
 }
 
 .app-sidebar[data-compact='true'][data-visible='true'] {
@@ -516,10 +517,10 @@ button.small {
 }
 
 .app-sidebar__content {
-  padding: 22px 20px 24px;
+  padding: 20px 16px 24px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
   height: 100%;
   overflow-y: auto;
   scrollbar-width: none;
@@ -542,16 +543,14 @@ button.small {
 }
 
 .app-sidebar__toggle {
-  border: 1px solid rgba(20, 94, 168, 0.2);
-  background: rgba(20, 94, 168, 0.08);
-  color: var(--color-primary-variant);
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
 }
 
 .app-sidebar__toggle:hover {
-  background: rgba(20, 94, 168, 0.16);
-  border-color: rgba(20, 94, 168, 0.28);
+  background: rgba(20, 94, 168, 0.08);
   color: var(--color-primary);
-  transform: translateY(-1px);
 }
 
 .app-sidebar__toggle:focus-visible {
@@ -560,14 +559,13 @@ button.small {
 }
 
 .app-sidebar__toggle[data-open='true'] {
-  background: rgba(20, 94, 168, 0.22);
-  border-color: rgba(20, 94, 168, 0.4);
-  color: var(--color-on-primary-container);
+  background: rgba(20, 94, 168, 0.12);
+  color: var(--color-primary);
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__content {
   align-items: center;
-  padding-inline: 16px;
+  padding-inline: 12px;
 }
 
 .app-sidebar__nav ul {
@@ -576,74 +574,87 @@ button.small {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
 .app-sidebar__nav-item {
   width: 100%;
   border: none;
-  border-radius: 14px;
+  border-radius: 999px;
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 12px 14px;
+  gap: 16px;
+  padding: 10px 16px;
+  min-height: 48px;
   background: transparent;
   cursor: pointer;
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   text-align: left;
-  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .app-sidebar__nav-item:hover,
 .app-sidebar__nav-item:focus-visible {
   background: rgba(20, 94, 168, 0.08);
-  outline: none;
   color: var(--color-primary-variant);
-  transform: translateX(2px);
+}
+
+.app-sidebar__nav-item:focus-visible {
+  outline: 2px solid rgba(20, 94, 168, 0.35);
+  outline-offset: 2px;
 }
 
 .app-sidebar__nav-item[data-active='true'] {
   background: rgba(20, 94, 168, 0.16);
-  color: var(--color-primary-variant);
-  box-shadow: inset 0 0 0 1px rgba(20, 94, 168, 0.18);
+  color: var(--color-primary);
 }
 
 .app-sidebar__nav-item[data-active='true'] .app-sidebar__nav-icon {
-  background: rgba(20, 94, 168, 0.22);
   color: var(--color-primary);
 }
 
 .app-sidebar__nav-icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  background: rgba(20, 94, 168, 0.1);
-  color: var(--color-primary-variant);
-  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
 }
 
 .app-sidebar__nav-icon svg {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
 }
 
 .app-sidebar__nav-text {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .app-sidebar__nav-label {
-  font-weight: 650;
+  font-weight: 600;
   font-size: 0.95rem;
+  color: var(--color-text-primary);
+}
+
+.app-sidebar__nav-item:hover .app-sidebar__nav-label,
+.app-sidebar__nav-item:focus-visible .app-sidebar__nav-label,
+.app-sidebar__nav-item[data-active='true'] .app-sidebar__nav-label {
+  color: inherit;
 }
 
 .app-sidebar__nav-description {
   font-size: 0.78rem;
   color: var(--color-text-secondary);
   line-height: 1.3;
+}
+
+.app-sidebar__nav-item[data-active='true'] .app-sidebar__nav-description {
+  color: inherit;
+  opacity: 0.9;
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__nav-text {
@@ -653,21 +664,24 @@ button.small {
 .app-sidebar[data-expanded='false'] .app-sidebar__nav-item {
   justify-content: center;
   padding: 12px;
-}
-
-.app-sidebar[data-expanded='false'] .app-sidebar__nav-icon {
-  background: rgba(20, 94, 168, 0.15);
+  border-radius: 16px;
 }
 
 .app-sidebar__section {
-  border: 1px solid transparent;
-  border-radius: 12px;
-  transition: border-color 0.2s ease, background-color 0.2s ease;
+  border-radius: 16px;
+  background: rgba(248, 250, 252, 0.8);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  padding: 8px 12px 12px;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .app-sidebar__section.is-open {
-  border-color: var(--color-outline);
-  background: rgba(20, 94, 168, 0.05);
+  background: rgba(20, 94, 168, 0.1);
+  border-color: rgba(20, 94, 168, 0.2);
+}
+
+.app-sidebar__section.is-open .app-sidebar__section-toggle {
+  color: var(--color-primary-variant);
 }
 
 .app-sidebar[data-expanded='false'] .app-sidebar__section {
@@ -676,15 +690,17 @@ button.small {
 
 .app-sidebar__section-toggle {
   width: 100%;
-  background: none;
+  background: transparent;
   border: none;
-  padding: 12px 8px;
+  padding: 12px 4px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--color-text-primary);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
   cursor: pointer;
 }
 
@@ -692,8 +708,8 @@ button.small {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 0 8px 12px;
-  font-size: 0.9rem;
+  padding: 0 4px 4px;
+  font-size: 0.88rem;
   color: var(--color-text-secondary);
 }
 


### PR DESCRIPTION
## Summary
- refresh the contextual sidebar layout with a flat, material-inspired drawer appearance
- simplify navigation items to use pill-shaped buttons, inherit icon colors, and highlight active/hover states with material tones
- restyle sidebar sections and toggles to match the updated navigation aesthetics

## Testing
- npm run lint *(fails: cannot find package '@eslint/js' referenced by the shared ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68e72eba48748330b23f1795aca682c8