### PR TITLE
Add centros de apoyo management to configuracion module

### DIFF
--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -49,6 +49,7 @@ type SidebarIconName =
   | 'sliders'
   | 'factory'
   | 'users'
+  | 'centros-apoyo'
   | 'workflow'
   | 'consumos'
   | 'producciones'
@@ -118,6 +119,13 @@ const buildConfiguracionNavigation = ({
       description: 'Administra ubicaciones, responsables y capacidades.',
       icon: 'factory',
       routeId: 'centros',
+    },
+    {
+      id: 'centros-apoyo',
+      label: 'Centros de apoyo',
+      description: 'Consulta gastos consolidados por centro de apoyo y administra sus nombres.',
+      icon: 'centros-apoyo',
+      routeId: 'centros-apoyo',
     },
     {
       id: 'empleados',
@@ -294,6 +302,15 @@ function SidebarIcon({ name }: { name: SidebarIconName }) {
         <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
           <path
             d="M16 11a4 4 0 1 0-8 0 4 4 0 0 0 8 0zm-4 6c-4.418 0-8 1.79-8 4v2h16v-2c0-2.21-3.582-4-8-4zm8-7a3 3 0 1 0-6 0 3 3 0 0 0 6 0zm-1 7c1.298.607 2 1.398 2 2.3V21h-3v-2c0-.673-.342-1.3-.959-1.87z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case 'centros-apoyo':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            d="M4 7a4 4 0 0 1 8 0v2H9v1h6V9h-3V7a4 4 0 0 1 8 0v10h2v2H2v-2h2zm2 0a2 2 0 0 1 4 0v2H6zm8 4H6v6h6v-3h2v3h4v-6z"
             fill="currentColor"
           />
         </svg>

--- a/frontend-app/src/modules/configuracion/__tests__/centrosApoyo.test.js
+++ b/frontend-app/src/modules/configuracion/__tests__/centrosApoyo.test.js
@@ -1,0 +1,51 @@
+import { buildCentrosApoyoSummary } from '../utils/centrosApoyo';
+
+const sampleExpenses = [
+  {
+    id: '1',
+    concepto: 'Energía',
+    categoria: 'Energía',
+    monto: 18250.45,
+    esGastoDelPeriodo: true,
+    fechaCalculo: '2024-05-31',
+  },
+  {
+    id: '2',
+    concepto: 'Caldera',
+    categoria: 'Caldera',
+    monto: 6200,
+    esGastoDelPeriodo: true,
+    fechaCalculo: '2024-05-31',
+  },
+  {
+    id: '3',
+    concepto: 'Refrigeración',
+    categoria: 'Energía',
+    monto: 4200,
+    esGastoDelPeriodo: false,
+    fechaCalculo: '2024-05-31',
+  },
+];
+
+describe('buildCentrosApoyoSummary', () => {
+  it('calcula totales y porcentajes por categoría', () => {
+    const summary = buildCentrosApoyoSummary(sampleExpenses);
+    expect(summary.total).toBeCloseTo(28650.45, 2);
+    expect(summary.periodTotal).toBeCloseTo(24450.45, 2);
+    expect(summary.outOfPeriodTotal).toBeCloseTo(4200, 2);
+    expect(summary.categories).toHaveLength(2);
+    expect(summary.categories[0].category).toBe('Energía');
+    expect(summary.categories[0].amount).toBeCloseTo(22450.45, 2);
+    expect(summary.categories[0].percentage).toBeCloseTo(22450.45 / 28650.45, 5);
+    expect(summary.categories[1].category).toBe('Caldera');
+    expect(summary.categories[1].amount).toBeCloseTo(6200, 2);
+  });
+
+  it('devuelve ceros cuando no hay gastos', () => {
+    const summary = buildCentrosApoyoSummary([]);
+    expect(summary.total).toBe(0);
+    expect(summary.periodTotal).toBe(0);
+    expect(summary.outOfPeriodTotal).toBe(0);
+    expect(summary.categories).toHaveLength(0);
+  });
+});

--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -291,6 +291,10 @@ textarea.config-input {
   overflow: auto;
 }
 
+.config-table tbody tr[data-selected='true'] {
+  background: rgba(20, 94, 168, 0.14);
+}
+
 .config-table {
   width: 100%;
   border-collapse: collapse;
@@ -605,4 +609,118 @@ textarea.config-input {
   .config-table__scroll {
     border-radius: 10px;
   }
+}
+
+.centros-apoyo {
+  gap: 24px;
+}
+
+.centros-apoyo__layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+@media (max-width: 1100px) {
+  .centros-apoyo__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.centros-apoyo__gastos,
+.centros-apoyo__edicion {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.centros-apoyo__section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.centros-apoyo__section-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-text-primary);
+}
+
+.centros-apoyo__section-header p {
+  margin: 4px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.centros-apoyo__actions {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.centros-apoyo__filters {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.centros-apoyo__filters-actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.centros-apoyo__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.centros-apoyo__summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(20, 94, 168, 0.18);
+  background: rgba(227, 239, 255, 0.7);
+  box-shadow: var(--shadow-level-1);
+}
+
+.centros-apoyo__summary-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  font-weight: 650;
+  color: var(--color-primary-variant);
+  text-transform: uppercase;
+}
+
+.centros-apoyo__summary-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.centros-apoyo__chart {
+  width: 100%;
+  border: 1px solid var(--color-outline);
+  border-radius: 16px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.centros-apoyo__warning {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(250, 204, 21, 0.45);
+  background: rgba(254, 240, 138, 0.4);
+  color: #854d0e;
+  font-weight: 600;
+}
+
+.centros-apoyo__cell-right {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }

--- a/frontend-app/src/modules/configuracion/hooks/useCentrosApoyo.ts
+++ b/frontend-app/src/modules/configuracion/hooks/useCentrosApoyo.ts
@@ -1,0 +1,173 @@
+import { useMemo } from 'react';
+import apiClient from '@/lib/http/apiClient';
+import { useCatalogData } from './useCatalogData';
+
+export interface CentroApoyo {
+  id: string;
+  nroCentro: number;
+  nombre: string;
+  fechaActualizacion?: string;
+}
+
+export interface CentroApoyoExpense {
+  id: string;
+  concepto: string;
+  categoria: string;
+  monto: number;
+  esGastoDelPeriodo: boolean;
+  fechaCalculo?: string;
+  centro?: string;
+}
+
+export interface CentroApoyoExpenseFilters {
+  fechaCalculo: string;
+  esGastoDelPeriodo?: boolean;
+}
+
+export interface CentroApoyoExpenseResponse {
+  items: CentroApoyoExpense[];
+  total: number;
+  count: number;
+  currency: string;
+}
+
+function mapCentroApoyo(raw: any): CentroApoyo {
+  const idCandidate = raw?._id ?? raw?.id ?? raw?.centroId ?? raw?.nroCentro;
+  const nro = Number(raw?.nroCentro ?? raw?.numero ?? raw?.centro ?? 0);
+  const nombre = typeof raw?.nombre === 'string' ? raw.nombre : String(raw?.descripcion ?? '');
+  const updatedAt =
+    typeof raw?.fechaActualizacion === 'string'
+      ? raw.fechaActualizacion
+      : typeof raw?.updatedAt === 'string'
+        ? raw.updatedAt
+        : undefined;
+
+  return {
+    id: idCandidate ? String(idCandidate) : `${nro}-${nombre}`,
+    nroCentro: Number.isFinite(nro) ? nro : 0,
+    nombre: nombre || 'Sin nombre',
+    fechaActualizacion: updatedAt,
+  };
+}
+
+function mapExpense(raw: any): CentroApoyoExpense {
+  const id = raw?._id ?? raw?.id ?? `${raw?.concepto ?? 'gasto'}-${raw?.fechaCalculo ?? raw?.fecha ?? Date.now()}`;
+  const rawMonto = raw?.monto ?? raw?.amount ?? raw?.total ?? 0;
+  const categoria = raw?.categoria ?? raw?.tipo ?? raw?.conceptoTipo ?? 'Sin categoría';
+  const rawPeriodo = raw?.esGastoDelPeriodo ?? raw?.delPeriodo ?? raw?.periodoActual;
+  let esDelPeriodo = false;
+  if (typeof rawPeriodo === 'boolean') {
+    esDelPeriodo = rawPeriodo;
+  } else if (typeof rawPeriodo === 'string') {
+    esDelPeriodo = rawPeriodo.toLowerCase() === 'true';
+  }
+
+  return {
+    id: String(id),
+    concepto: typeof raw?.concepto === 'string' ? raw.concepto : raw?.descripcion ?? 'Sin concepto',
+    categoria: String(categoria || 'Sin categoría'),
+    monto: Number.isFinite(rawMonto) ? Number(rawMonto) : 0,
+    esGastoDelPeriodo: Boolean(esDelPeriodo),
+    fechaCalculo:
+      typeof raw?.fechaCalculo === 'string'
+        ? raw.fechaCalculo
+        : typeof raw?.calculationDate === 'string'
+          ? raw.calculationDate
+          : typeof raw?.fecha === 'string'
+            ? raw.fecha
+            : undefined,
+    centro: typeof raw?.centro === 'string' ? raw.centro : undefined,
+  };
+}
+
+export function useCentrosApoyoCatalog() {
+  const catalog = useCatalogData<CentroApoyo>({
+    resource: 'centros-apoyo',
+    mapResponse: mapCentroApoyo,
+  });
+
+  const orderedItems = useMemo(
+    () => [...catalog.items].sort((a, b) => a.nroCentro - b.nroCentro),
+    [catalog.items],
+  );
+
+  return { ...catalog, items: orderedItems } as const;
+}
+
+export async function fetchCentroApoyoDetalle(id: string, options: { signal?: AbortSignal } = {}): Promise<CentroApoyo> {
+  const data = await apiClient.get<unknown>(`/api/centros-apoyo/${id}`, options);
+  return mapCentroApoyo(data);
+}
+
+export async function actualizarCentroApoyo(
+  id: string,
+  payload: { nombre: string },
+  options: { signal?: AbortSignal } = {},
+): Promise<void> {
+  await apiClient.put(`/api/centros-apoyo/${id}`, payload, options);
+}
+
+function buildExpenseQuery(centroId: string, filters: CentroApoyoExpenseFilters): string {
+  const params = new URLSearchParams();
+  if (centroId) {
+    params.set('centroId', centroId);
+  }
+  if (filters.fechaCalculo) {
+    params.set('fechaCalculo', filters.fechaCalculo);
+  }
+  if (filters.esGastoDelPeriodo !== undefined) {
+    params.set('esGastoDelPeriodo', String(filters.esGastoDelPeriodo));
+  }
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export async function listCentroApoyoGastos(
+  centroId: string,
+  filters: CentroApoyoExpenseFilters,
+  options: { signal?: AbortSignal } = {},
+): Promise<CentroApoyoExpenseResponse> {
+  const query = buildExpenseQuery(centroId, filters);
+  const response = await apiClient.get<unknown>(`/api/centros-apoyo/gastos${query}`, options);
+
+  let items: unknown[] = [];
+  let total = 0;
+  let count = 0;
+  let currency = 'MXN';
+
+  if (Array.isArray(response)) {
+    items = response;
+  } else if (response && typeof response === 'object') {
+    const data = response as Record<string, unknown>;
+    if (Array.isArray(data.items)) {
+      items = data.items;
+    } else if (Array.isArray(data.data)) {
+      items = data.data;
+    } else if (Array.isArray(data.result)) {
+      items = data.result;
+    }
+    if (typeof data.total === 'number') {
+      total = data.total;
+    } else if (typeof data.totalAmount === 'number') {
+      total = data.totalAmount;
+    }
+    if (typeof data.count === 'number') {
+      count = data.count;
+    }
+    if (typeof data.currency === 'string') {
+      currency = data.currency;
+    }
+  }
+
+  const expenses = items.map(mapExpense);
+  if (total === 0) {
+    total = expenses.reduce((acc, item) => acc + item.monto, 0);
+  }
+  if (!count) {
+    count = expenses.length;
+  }
+
+  return { items: expenses, total, count, currency };
+}
+
+export type { CentroApoyoExpenseFilters as CentrosApoyoFilters };

--- a/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
@@ -1,0 +1,602 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { formatCurrency } from '@/lib/formatters';
+import { useToast } from '../context/ToastContext';
+import { useConfigContext } from '../context/ConfigContext';
+import CatalogTable, { type CatalogTableColumn } from '../components/CatalogTable';
+import FormSection from '../components/FormSection';
+import ProtectedRoute from '../components/ProtectedRoute';
+import {
+  actualizarCentroApoyo,
+  fetchCentroApoyoDetalle,
+  listCentroApoyoGastos,
+  useCentrosApoyoCatalog,
+  type CentroApoyo,
+  type CentroApoyoExpense,
+  type CentroApoyoExpenseFilters,
+} from '../hooks/useCentrosApoyo';
+import { useForm } from '../hooks/useForm';
+import {
+  centroApoyoValidator,
+  defaultCentroApoyoValues,
+  type CentroApoyoFormValues,
+} from '../schemas/centroApoyoSchema';
+import { buildCentrosApoyoSummary } from '../utils/centrosApoyo';
+import type { CentroApoyoExpenseSummary } from '../utils/centrosApoyo';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
+
+const FILTER_STORAGE_KEY = 'configuracion.centrosApoyo.filtros';
+const CHART_COLORS = ['#145ea8', '#0f766e', '#f97316', '#9333ea', '#ef4444', '#0ea5e9'];
+
+const defaultFilters: CentroApoyoExpenseFilters = {
+  fechaCalculo: '',
+  esGastoDelPeriodo: undefined,
+};
+
+function loadStoredFilters(): CentroApoyoExpenseFilters {
+  if (typeof window === 'undefined') {
+    return defaultFilters;
+  }
+  try {
+    const raw = window.localStorage.getItem(FILTER_STORAGE_KEY);
+    if (!raw) return defaultFilters;
+    const parsed = JSON.parse(raw) as Partial<CentroApoyoExpenseFilters>;
+    return {
+      fechaCalculo: typeof parsed.fechaCalculo === 'string' ? parsed.fechaCalculo : '',
+      esGastoDelPeriodo:
+        typeof parsed.esGastoDelPeriodo === 'boolean' ? parsed.esGastoDelPeriodo : undefined,
+    };
+  } catch (error) {
+    console.warn('[centros-apoyo] No se pudieron cargar filtros guardados', error);
+    return defaultFilters;
+  }
+}
+
+function persistFilters(filters: CentroApoyoExpenseFilters) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(filters));
+  } catch (error) {
+    console.warn('[centros-apoyo] No se pudieron guardar los filtros', error);
+  }
+}
+
+function formatDate(value?: string) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString();
+}
+
+function formatDateTime(value?: string) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+function exportToCsv(records: CentroApoyoExpense[], centro?: CentroApoyo) {
+  if (records.length === 0) {
+    return;
+  }
+  const header = ['Concepto', 'Categoría', 'Monto', 'Del periodo', 'Fecha cálculo'];
+  const rows = records.map((record) => [
+    record.concepto,
+    record.categoria,
+    record.monto.toString(),
+    record.esGastoDelPeriodo ? 'Sí' : 'No',
+    record.fechaCalculo ?? '',
+  ]);
+  const csvContent = [header, ...rows]
+    .map((line) => line.map((value) => `"${String(value).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  const centroLabel = centro ? `centro-${centro.nroCentro.toString().padStart(3, '0')}` : 'centro';
+  link.download = `gastos-${centroLabel}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+const CentrosApoyoPage: React.FC = () => {
+  const { activeRoute } = useConfigContext();
+  const { showToast } = useToast();
+  const catalog = useCentrosApoyoCatalog();
+  const [selectedCentroId, setSelectedCentroId] = useState<string | null>(null);
+  const [filters, setFilters] = useState<CentroApoyoExpenseFilters>(() => loadStoredFilters());
+  const [gastos, setGastos] = useState<CentroApoyoExpense[]>([]);
+  const [gastosSummary, setGastosSummary] = useState<CentroApoyoExpenseSummary>(() =>
+    buildCentrosApoyoSummary([]),
+  );
+  const [gastosCurrency, setGastosCurrency] = useState('MXN');
+  const [gastosLoading, setGastosLoading] = useState(false);
+  const [gastosError, setGastosError] = useState<string | null>(null);
+  const [gastosWarning, setGastosWarning] = useState<string | null>(null);
+  const [gastosCount, setGastosCount] = useState(0);
+  const checkboxRef = useRef<HTMLInputElement | null>(null);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingCentro, setEditingCentro] = useState<CentroApoyo | null>(null);
+  const [loadingDetalle, setLoadingDetalle] = useState(false);
+
+  const form = useForm<CentroApoyoFormValues>({
+    defaultValues: defaultCentroApoyoValues,
+    validator: centroApoyoValidator,
+  });
+
+  useEffect(() => {
+    checkboxRef.current && (checkboxRef.current.indeterminate = filters.esGastoDelPeriodo === undefined);
+  }, [filters.esGastoDelPeriodo]);
+
+  const selectedCentro = useMemo(
+    () => catalog.items.find((centro) => centro.id === selectedCentroId) ?? null,
+    [catalog.items, selectedCentroId],
+  );
+
+  useEffect(() => {
+    if (!selectedCentroId && catalog.items.length > 0) {
+      setSelectedCentroId(catalog.items[0].id);
+    }
+  }, [catalog.items, selectedCentroId]);
+
+  useEffect(() => {
+    persistFilters(filters);
+  }, [filters]);
+
+  const fetchGastos = useCallback(
+    async (options: { signal?: AbortSignal; silent?: boolean } = {}) => {
+      if (!selectedCentroId) {
+        setGastos([]);
+        setGastosSummary(buildCentrosApoyoSummary([]));
+        setGastosCount(0);
+        return;
+      }
+
+      if (!filters.fechaCalculo) {
+        setGastos([]);
+        setGastosSummary(buildCentrosApoyoSummary([]));
+        setGastosWarning('Selecciona una fecha de cálculo para consultar los gastos del centro.');
+        setGastosError(null);
+        setGastosCount(0);
+        return;
+      }
+
+      if (!options.silent) {
+        setGastosLoading(true);
+      }
+      setGastosWarning(null);
+      setGastosError(null);
+
+      try {
+        const response = await listCentroApoyoGastos(selectedCentroId, filters, { signal: options.signal });
+        if (options.signal?.aborted) {
+          return;
+        }
+        setGastos(response.items);
+        setGastosSummary(buildCentrosApoyoSummary(response.items));
+        setGastosCurrency(response.currency);
+        setGastosCount(response.count);
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          return;
+        }
+        setGastosError('No se pudieron cargar los gastos del centro seleccionado.');
+      } finally {
+        if (!options.silent) {
+          setGastosLoading(false);
+        }
+      }
+    },
+    [filters, selectedCentroId],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchGastos({ signal: controller.signal });
+    return () => controller.abort();
+  }, [fetchGastos]);
+
+  const handleSelectCentro = useCallback(
+    (centro: CentroApoyo) => {
+      setSelectedCentroId(centro.id);
+      setIsEditing(false);
+      setEditingCentro(null);
+      form.reset();
+    },
+    [form],
+  );
+
+  const handleEditCentro = useCallback(
+    async (centro: CentroApoyo) => {
+      setIsEditing(true);
+      setLoadingDetalle(true);
+      try {
+        const detalle = await fetchCentroApoyoDetalle(centro.id);
+        setEditingCentro(detalle);
+        form.reset({
+          nombre: detalle.nombre,
+          nroCentro: detalle.nroCentro.toString(),
+        });
+      } catch (error) {
+        showToast('No se pudo cargar el centro seleccionado.', 'error');
+        setIsEditing(false);
+      } finally {
+        setLoadingDetalle(false);
+      }
+    },
+    [form, showToast],
+  );
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    if (!editingCentro) {
+      return;
+    }
+    try {
+      await actualizarCentroApoyo(editingCentro.id, { nombre: values.nombre.trim() });
+      showToast('Centro actualizado correctamente.', 'success');
+      setIsEditing(false);
+      setEditingCentro(null);
+      form.reset();
+      await catalog.refetch();
+      await fetchGastos({ silent: true });
+    } catch (error) {
+      showToast('No se pudo actualizar el centro. Verifica que exista e inténtalo nuevamente.', 'error');
+    }
+  });
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditingCentro(null);
+    form.reset();
+  };
+
+  const handleFiltersChange = (updater: (current: CentroApoyoExpenseFilters) => CentroApoyoExpenseFilters) => {
+    setFilters((current) => updater(current));
+  };
+
+  const handleClearFilters = () => {
+    setFilters(defaultFilters);
+  };
+
+  const handleExport = () => {
+    if (!selectedCentro) {
+      showToast('Selecciona un centro para exportar sus gastos.', 'warning');
+      return;
+    }
+    if (gastos.length === 0) {
+      showToast('No hay gastos para exportar con los filtros seleccionados.', 'warning');
+      return;
+    }
+    exportToCsv(gastos, selectedCentro);
+    showToast('Exportación generada correctamente.', 'success');
+  };
+
+  const columns: CatalogTableColumn<CentroApoyo>[] = useMemo(
+    () => [
+      {
+        key: 'nroCentro',
+        label: 'N° centro',
+        width: '120px',
+        render: (centro) => centro.nroCentro.toString().padStart(3, '0'),
+      },
+      { key: 'nombre', label: 'Nombre del centro' },
+      {
+        key: 'fechaActualizacion',
+        label: 'Última actualización',
+        width: '180px',
+        render: (centro) => formatDateTime(centro.fechaActualizacion),
+      },
+      {
+        key: 'acciones',
+        label: 'Acciones',
+        width: '220px',
+        render: (centro) => (
+          <div className="catalog-row-actions">
+            <button type="button" className="catalog-row-actions__edit" onClick={() => handleSelectCentro(centro)}>
+              <span aria-hidden="true">👁️</span>
+              Ver gastos
+            </button>
+            <ProtectedRoute
+              permissions={[activeRoute?.meta.permissions.write ?? 'catalogos.write']}
+              fallback={null}
+            >
+              <button type="button" className="catalog-row-actions__edit" onClick={() => handleEditCentro(centro)}>
+                <span className="catalog-row-actions__icon" aria-hidden="true">
+                  ✏️
+                </span>
+                Editar
+              </button>
+            </ProtectedRoute>
+          </div>
+        ),
+      },
+    ],
+    [activeRoute?.meta.permissions.write, handleEditCentro, handleSelectCentro],
+  );
+
+  const isSaveDisabled = useMemo(() => {
+    if (!editingCentro) {
+      return true;
+    }
+    const currentNombre = form.formState.values.nombre.trim();
+    return currentNombre.length === 0 || currentNombre === editingCentro.nombre;
+  }, [editingCentro, form.formState.values.nombre]);
+
+  const chartData = useMemo(
+    () =>
+      gastosSummary.categories.map((item) => ({
+        name: item.category,
+        value: Number(item.amount.toFixed(2)),
+      })),
+    [gastosSummary.categories],
+  );
+
+  return (
+    <div className="catalog-view centros-apoyo">
+      <section className="catalog-view__panel">
+        <header className="catalog-view__header">
+          <div className="catalog-view__header-text">
+            <h2 className="catalog-view__title">Centros de apoyo</h2>
+            <p className="catalog-view__subtitle">
+              Administra la información de los centros y consulta los gastos consolidados por periodo.
+            </p>
+          </div>
+          <div className="catalog-view__actions">
+            <span className="catalog-view__meta">{catalog.items.length} centros registrados</span>
+            <button type="button" className="secondary" onClick={() => catalog.refetch()} disabled={catalog.isLoading}>
+              Actualizar catálogo
+            </button>
+          </div>
+        </header>
+
+        <div className="catalog-card">
+          {catalog.error && (
+            <div className="config-alert" role="alert">
+              <span>No pudimos cargar los centros de apoyo.</span>
+              <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
+                Reintentar
+              </button>
+            </div>
+          )}
+
+          <CatalogTable
+            rows={catalog.items}
+            columns={columns}
+            loading={catalog.isLoading}
+            emptyMessage="No hay centros de apoyo registrados."
+          />
+        </div>
+      </section>
+
+      <div className="centros-apoyo__layout">
+        <section className="catalog-card centros-apoyo__gastos">
+          <header className="centros-apoyo__section-header">
+            <div>
+              <h3>Gastos consolidados</h3>
+              <p>
+                {selectedCentro
+                  ? `Mostrando información de ${selectedCentro.nombre} (centro ${selectedCentro.nroCentro.toString().padStart(3, '0')}).`
+                  : 'Selecciona un centro para visualizar sus gastos asociados.'}
+              </p>
+            </div>
+            <div className="centros-apoyo__actions">
+              <button type="button" className="secondary" onClick={() => fetchGastos()} disabled={gastosLoading}>
+                Refrescar
+              </button>
+              <button type="button" className="secondary" onClick={handleExport}>
+                Exportar CSV
+              </button>
+            </div>
+          </header>
+
+          <div className="centros-apoyo__filters">
+            <label className="config-form-field">
+              <span className="config-field-label">Fecha de cálculo</span>
+              <input
+                type="date"
+                className="config-input"
+                value={filters.fechaCalculo}
+                onChange={(event) =>
+                  handleFiltersChange((current) => ({ ...current, fechaCalculo: event.target.value }))
+                }
+              />
+            </label>
+            <div className="config-form-field config-form-field--inline">
+              <span className="config-field-label">Gastos del periodo</span>
+              <label className="config-checkbox">
+                <input
+                  ref={checkboxRef}
+                  type="checkbox"
+                  checked={filters.esGastoDelPeriodo ?? false}
+                  onChange={(event) =>
+                    handleFiltersChange((current) => ({
+                      ...current,
+                      esGastoDelPeriodo: event.target.checked,
+                    }))
+                  }
+                />
+                Solo del periodo
+              </label>
+              <button
+                type="button"
+                className="ghost"
+                onClick={() => handleFiltersChange((current) => ({ ...current, esGastoDelPeriodo: undefined }))}
+              >
+                Limpiar estado
+              </button>
+            </div>
+            <div className="centros-apoyo__filters-actions">
+              <button type="button" className="ghost" onClick={handleClearFilters}>
+                Limpiar filtros
+              </button>
+            </div>
+          </div>
+
+          {gastosWarning && <div className="centros-apoyo__warning">{gastosWarning}</div>}
+          {gastosError && !gastosWarning && <div className="config-alert">{gastosError}</div>}
+
+          {gastosLoading ? (
+            <div className="table-empty">Cargando gastos…</div>
+          ) : gastos.length === 0 ? (
+            <div className="table-empty">
+              {gastosWarning
+                ? 'Selecciona una fecha de cálculo para comenzar.'
+                : 'No se encontraron gastos con los filtros seleccionados.'}
+            </div>
+          ) : (
+            <>
+              <div className="centros-apoyo__summary">
+                <div className="centros-apoyo__summary-card">
+                  <span className="centros-apoyo__summary-label">Total de gastos</span>
+                  <span className="centros-apoyo__summary-value">
+                    {formatCurrency(gastosSummary.total, { currency: gastosCurrency })}
+                  </span>
+                </div>
+                <div className="centros-apoyo__summary-card">
+                  <span className="centros-apoyo__summary-label">Del periodo</span>
+                  <span className="centros-apoyo__summary-value">
+                    {formatCurrency(gastosSummary.periodTotal, { currency: gastosCurrency })}
+                  </span>
+                </div>
+                <div className="centros-apoyo__summary-card">
+                  <span className="centros-apoyo__summary-label">Fuera del periodo</span>
+                  <span className="centros-apoyo__summary-value">
+                    {formatCurrency(gastosSummary.outOfPeriodTotal, { currency: gastosCurrency })}
+                  </span>
+                </div>
+                <div className="centros-apoyo__summary-card">
+                  <span className="centros-apoyo__summary-label">Registros</span>
+                  <span className="centros-apoyo__summary-value">{gastosCount}</span>
+                </div>
+              </div>
+
+              {chartData.length > 0 && (
+                <div className="centros-apoyo__chart" role="img" aria-label="Distribución de gastos por categoría">
+                  <ResponsiveContainer width="100%" height={220}>
+                    <PieChart>
+                      <Pie data={chartData} dataKey="value" nameKey="name" innerRadius={60} outerRadius={90}>
+                        {chartData.map((entry, index) => (
+                          <Cell key={`cell-${entry.name}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip formatter={(value: number) => formatCurrency(value, { currency: gastosCurrency })} />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              )}
+
+              <div className="config-table__scroll">
+                <table className="config-table">
+                  <thead>
+                    <tr>
+                      <th>Concepto</th>
+                      <th>Categoría</th>
+                      <th>Monto</th>
+                      <th>Del periodo</th>
+                      <th>Fecha cálculo</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {gastos.map((gasto) => (
+                      <tr key={gasto.id}>
+                        <td>{gasto.concepto}</td>
+                        <td>{gasto.categoria}</td>
+                        <td className="centros-apoyo__cell-right">
+                          {formatCurrency(gasto.monto, { currency: gastosCurrency })}
+                        </td>
+                        <td>
+                          <span className={`badge ${gasto.esGastoDelPeriodo ? 'badge--activo' : 'badge--inactivo'}`}>
+                            {gasto.esGastoDelPeriodo ? 'Sí' : 'No'}
+                          </span>
+                        </td>
+                        <td>{formatDate(gasto.fechaCalculo)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </section>
+
+        <section className="catalog-card centros-apoyo__edicion">
+          <header className="centros-apoyo__section-header">
+            <div>
+              <h3>Editar centro</h3>
+              <p>Actualiza únicamente el nombre del centro de apoyo seleccionado.</p>
+            </div>
+          </header>
+
+          {!isEditing ? (
+            <div className="table-empty">
+              {selectedCentro
+                ? 'Selecciona “Editar” desde el listado para modificar el nombre del centro.'
+                : 'Elige un centro del listado para habilitar la edición.'}
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} noValidate className="config-form">
+              <FormSection title="Datos del centro">
+                <div className="config-form-field">
+                  <label htmlFor="centro-apoyo-nro" className="config-field-label">
+                    Número de centro
+                  </label>
+                  <input
+                    id="centro-apoyo-nro"
+                    className="config-input"
+                    {...form.register('nroCentro')}
+                    readOnly
+                    disabled
+                  />
+                  {form.formState.errors.nroCentro && (
+                    <p className="config-field-error">{form.formState.errors.nroCentro}</p>
+                  )}
+                </div>
+                <div className="config-form-field">
+                  <label htmlFor="centro-apoyo-nombre" className="config-field-label">
+                    Nombre del centro
+                  </label>
+                  <input
+                    id="centro-apoyo-nombre"
+                    className="config-input"
+                    placeholder="Ingresa el nombre"
+                    {...form.register('nombre')}
+                  />
+                  {form.formState.errors.nombre && (
+                    <p className="config-field-error">{form.formState.errors.nombre}</p>
+                  )}
+                </div>
+              </FormSection>
+
+              <div className="config-form-actions">
+                <button type="button" className="ghost" onClick={handleCancelEdit}>
+                  Cancelar
+                </button>
+                <ProtectedRoute
+                  permissions={[activeRoute?.meta.permissions.write ?? 'catalogos.write']}
+                  fallback={null}
+                >
+                  <button type="submit" className="primary" disabled={isSaveDisabled || form.formState.isSubmitting}>
+                    {form.formState.isSubmitting ? 'Guardando…' : 'Guardar cambios'}
+                  </button>
+                </ProtectedRoute>
+              </div>
+            </form>
+          )}
+
+          {loadingDetalle && <div className="table-empty">Cargando detalles…</div>}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default CentrosApoyoPage;

--- a/frontend-app/src/modules/configuracion/routes.tsx
+++ b/frontend-app/src/modules/configuracion/routes.tsx
@@ -3,6 +3,7 @@ import ActividadesPage from './pages/ActividadesPage';
 import CentrosPage from './pages/CentrosPage';
 import EmpleadosPage from './pages/EmpleadosPage';
 import ParametrosGeneralesPage from './pages/ParametrosGeneralesPage';
+import CentrosApoyoPage from './pages/CentrosApoyoPage';
 import type { ConfigRoute } from './types';
 
 export function buildConfigRoutes(): ConfigRoute[] {
@@ -62,6 +63,20 @@ export function buildConfigRoutes(): ConfigRoute[] {
         secondaryNavLabel: 'Parámetros',
       },
       element: <ParametrosGeneralesPage />,
+    },
+    {
+      id: 'centros-apoyo',
+      path: 'centros-apoyo',
+      meta: {
+        title: 'Centros de apoyo',
+        description: 'Consulta y administra los centros de apoyo y sus gastos consolidados por periodo.',
+        breadcrumb: ['Configuración', 'Costos', 'Centros de apoyo'],
+        permissions: { read: 'catalogos.read', write: 'catalogos.write' },
+        featureFlag: 'catalogoCentrosApoyo',
+        dependencies: ['costos', 'existencias'],
+        secondaryNavLabel: 'Centros de apoyo',
+      },
+      element: <CentrosApoyoPage />,
     },
   ];
 }

--- a/frontend-app/src/modules/configuracion/schemas/centroApoyoSchema.ts
+++ b/frontend-app/src/modules/configuracion/schemas/centroApoyoSchema.ts
@@ -1,0 +1,42 @@
+import type { Validator } from './types';
+
+export interface CentroApoyoFormValues {
+  nroCentro: string;
+  nombre: string;
+}
+
+export const defaultCentroApoyoValues: CentroApoyoFormValues = {
+  nroCentro: '',
+  nombre: '',
+};
+
+export const centroApoyoValidator: Validator<CentroApoyoFormValues> = (input) => {
+  const issues: Array<{ path: keyof CentroApoyoFormValues; message: string }> = [];
+  const raw = (input ?? {}) as Partial<Record<keyof CentroApoyoFormValues, unknown>>;
+
+  const nroCentroValue = 'nroCentro' in raw ? String(raw.nroCentro ?? '') : '';
+  const nombreValue = 'nombre' in raw ? String(raw.nombre ?? '') : '';
+  const trimmedNombre = nombreValue.trim();
+
+  if (!trimmedNombre) {
+    issues.push({ path: 'nombre', message: 'El nombre es obligatorio.' });
+  } else if (trimmedNombre.length < 3 || trimmedNombre.length > 120) {
+    issues.push({ path: 'nombre', message: 'El nombre debe tener entre 3 y 120 caracteres.' });
+  }
+
+  if (!nroCentroValue) {
+    issues.push({ path: 'nroCentro', message: 'No se pudo identificar el número de centro.' });
+  }
+
+  if (issues.length > 0) {
+    return { success: false, issues };
+  }
+
+  return {
+    success: true,
+    data: {
+      nroCentro: nroCentroValue,
+      nombre: trimmedNombre,
+    },
+  };
+};

--- a/frontend-app/src/modules/configuracion/stores/featureFlags.ts
+++ b/frontend-app/src/modules/configuracion/stores/featureFlags.ts
@@ -7,6 +7,7 @@ const state: FeatureFlagsState = {
   catalogoEmpleados: true,
   catalogoCentros: true,
   parametrosGenerales: false,
+  catalogoCentrosApoyo: true,
 };
 
 const listeners = new Set<(flags: FeatureFlagsState) => void>();

--- a/frontend-app/src/modules/configuracion/types.ts
+++ b/frontend-app/src/modules/configuracion/types.ts
@@ -48,7 +48,8 @@ export type FeatureFlagKey =
   | 'catalogoActividades'
   | 'catalogoEmpleados'
   | 'catalogoCentros'
-  | 'parametrosGenerales';
+  | 'parametrosGenerales'
+  | 'catalogoCentrosApoyo';
 
 export interface CatalogFilterState {
   search: string;

--- a/frontend-app/src/modules/configuracion/utils/centrosApoyo.ts
+++ b/frontend-app/src/modules/configuracion/utils/centrosApoyo.ts
@@ -1,0 +1,48 @@
+import type { CentroApoyoExpense } from '../hooks/useCentrosApoyo';
+
+export interface CentroApoyoCategoryBreakdown {
+  category: string;
+  amount: number;
+  percentage: number;
+}
+
+export interface CentroApoyoExpenseSummary {
+  total: number;
+  periodTotal: number;
+  outOfPeriodTotal: number;
+  categories: CentroApoyoCategoryBreakdown[];
+}
+
+export function buildCentrosApoyoSummary(expenses: CentroApoyoExpense[]): CentroApoyoExpenseSummary {
+  let total = 0;
+  let periodTotal = 0;
+  let outOfPeriodTotal = 0;
+  const categoryTotals = new Map<string, number>();
+
+  for (const expense of expenses) {
+    const amount = Number.isFinite(expense.monto) ? expense.monto : 0;
+    total += amount;
+    if (expense.esGastoDelPeriodo) {
+      periodTotal += amount;
+    } else {
+      outOfPeriodTotal += amount;
+    }
+    const key = expense.categoria || 'Sin categoría';
+    categoryTotals.set(key, (categoryTotals.get(key) ?? 0) + amount);
+  }
+
+  const categories: CentroApoyoCategoryBreakdown[] = Array.from(categoryTotals.entries())
+    .map(([category, amount]) => ({
+      category,
+      amount,
+      percentage: total > 0 ? amount / total : 0,
+    }))
+    .sort((a, b) => b.amount - a.amount);
+
+  return {
+    total,
+    periodTotal,
+    outOfPeriodTotal,
+    categories,
+  };
+}


### PR DESCRIPTION
## Summary
- add a Centros de Apoyo experience inside Configuración with filtros persistentes, exportación CSV y resumen visual
- crear hooks, validadores y utilidades para consultar y resumir los gastos de centros de apoyo
- actualizar navegación, feature flags y estilos para integrar el nuevo submódulo

## Testing
- npm run test *(falla: no se pudieron instalar dependencias debido a restricciones del registro)*

------
https://chatgpt.com/codex/tasks/task_e_68e73413158c833098a22d890185fd76