### PR TITLE
fix: disable placeholder actions and simulate costos process

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -445,6 +445,15 @@ button.small {
   transform: translateY(-1px);
 }
 
+.app-navbar__action[disabled],
+.app-navbar__action[disabled]:hover {
+  cursor: not-allowed;
+  background: rgba(15, 23, 42, 0.18);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.75);
+  transform: none;
+}
+
 .app-navbar__action--primary {
   background: rgba(59, 130, 246, 0.85);
   border-color: rgba(96, 165, 250, 0.9);
@@ -455,6 +464,13 @@ button.small {
   background: rgba(37, 99, 235, 0.92);
   border-color: rgba(59, 130, 246, 0.95);
   color: #f8fafc;
+}
+
+.app-navbar__action--primary[disabled],
+.app-navbar__action--primary[disabled]:hover {
+  background: rgba(59, 130, 246, 0.5);
+  border-color: rgba(96, 165, 250, 0.45);
+  color: rgba(248, 250, 252, 0.8);
 }
 
 .app-shell__content {
@@ -770,6 +786,13 @@ button.small {
 
 .app-sidebar__link:hover {
   background: rgba(20, 94, 168, 0.12);
+}
+
+.app-sidebar__link[disabled],
+.app-sidebar__link[disabled]:hover {
+  cursor: not-allowed;
+  color: var(--color-text-secondary);
+  background: none;
 }
 
 .app-main {

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -24,6 +24,8 @@ type DomainKey = 'configuracion' | 'operacion' | 'importaciones' | 'costos' | 'r
 type DomainAction = {
   label: string;
   variant?: 'primary' | 'default';
+  disabled?: boolean;
+  description?: string;
 };
 
 type SidebarStat = {
@@ -163,8 +165,17 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     subtitle: 'Administra los catálogos maestros y parámetros generales utilizados por los módulos operativos.',
     logo: '🌿',
     actions: [
-      { label: 'Agregar catálogo', variant: 'primary' },
-      { label: 'Centro de ayuda' },
+      {
+        label: 'Agregar catálogo',
+        variant: 'primary',
+        disabled: true,
+        description: 'Disponible cuando se integre el flujo de alta de catálogos con el backend.',
+      },
+      {
+        label: 'Centro de ayuda',
+        disabled: true,
+        description: 'Enlace en preparación; se habilitará al publicar la documentación oficial.',
+      },
     ],
     overview: {
       description:
@@ -184,8 +195,17 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
       'Captura y monitorea consumos, producciones, litros, pérdidas y sobrantes con trazabilidad y cierres controlados.',
     logo: '🛠️',
     actions: [
-      { label: 'Nueva importación', variant: 'primary' },
-      { label: 'Ver bitácoras' },
+      {
+        label: 'Nueva importación',
+        variant: 'primary',
+        disabled: true,
+        description: 'Acceso directo pendiente; utiliza el módulo de Importaciones para realizar cargas.',
+      },
+      {
+        label: 'Ver bitácoras',
+        disabled: true,
+        description: 'Se habilitará cuando se publique el listado resumido de bitácoras.',
+      },
     ],
     overview: {
       description:
@@ -205,8 +225,17 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
       'Controla gastos, depreciaciones, sueldos y monitorea las consolidaciones automáticas con trazabilidad completa.',
     logo: '💰',
     actions: [
-      { label: 'Reprocesar consolidación', variant: 'primary' },
-      { label: 'Historial de bitácoras' },
+      {
+        label: 'Reprocesar consolidación',
+        variant: 'primary',
+        disabled: true,
+        description: 'La consolidación se ejecuta automáticamente; esta acción se reservará para el backend real.',
+      },
+      {
+        label: 'Historial de bitácoras',
+        disabled: true,
+        description: 'Acceso directo pendiente; consulta el módulo de Costos para los detalles.',
+      },
     ],
     overview: {
       description:
@@ -226,8 +255,17 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
       'Explora indicadores financieros, operativos y de auditoría con filtros avanzados y exportaciones seguras.',
     logo: '📊',
     actions: [
-      { label: 'Descargar guía rápida' },
-      { label: 'Solicitar nuevo reporte', variant: 'primary' },
+      {
+        label: 'Descargar guía rápida',
+        disabled: true,
+        description: 'La guía estará disponible cuando se publique la documentación de reportes.',
+      },
+      {
+        label: 'Solicitar nuevo reporte',
+        variant: 'primary',
+        disabled: true,
+        description: 'Funcionalidad pendiente de integrar con el flujo de solicitudes.',
+      },
     ],
     overview: {
       description:
@@ -247,8 +285,17 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
       'Carga archivos .mdb, monitorea el procesamiento por tabla y gestiona las bitácoras generadas automáticamente.',
     logo: '📥',
     actions: [
-      { label: 'Nueva importación', variant: 'primary' },
-      { label: 'Bitácoras recientes' },
+      {
+        label: 'Nueva importación',
+        variant: 'primary',
+        disabled: true,
+        description: 'Utiliza la pestaña Importar archivo para ejecutar cargas mientras se habilita este acceso rápido.',
+      },
+      {
+        label: 'Bitácoras recientes',
+        disabled: true,
+        description: 'Se activará cuando se exponga el resumen de bitácoras.',
+      },
     ],
     overview: {
       description:
@@ -662,6 +709,9 @@ function App() {
                 key={action.label}
                 type="button"
                 className={`app-navbar__action${action.variant === 'primary' ? ' app-navbar__action--primary' : ''}`}
+                disabled={action.disabled ?? false}
+                aria-disabled={action.disabled ? 'true' : undefined}
+                title={action.disabled ? action.description ?? 'Acción disponible próximamente.' : undefined}
               >
                 {action.label}
               </button>
@@ -715,6 +765,7 @@ function App() {
                         tabIndex={item.onSelect ? 0 : -1}
                         onClick={item.onSelect}
                         disabled={!item.onSelect}
+                        title={!item.onSelect ? 'Sección informativa disponible próximamente' : undefined}
                         data-active={item.isActive ?? false}
                         aria-pressed={item.isActive ?? undefined}
                         aria-current={item.isActive ? 'page' : undefined}
@@ -769,7 +820,13 @@ function App() {
                   <ul className="app-sidebar__links">
                     {domainConfig.shortcuts.map((shortcut) => (
                       <li key={shortcut}>
-                        <button type="button" className="app-sidebar__link">
+                        <button
+                          type="button"
+                          className="app-sidebar__link"
+                          disabled
+                          title="Disponible próximamente"
+                          aria-disabled="true"
+                        >
                           {shortcut}
                         </button>
                       </li>

--- a/frontend-app/src/modules/costos/components/CostosDataTable.tsx
+++ b/frontend-app/src/modules/costos/components/CostosDataTable.tsx
@@ -105,6 +105,9 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
             className={
               action.intent === 'primary' ? 'primary' : action.intent === 'secondary' ? 'secondary' : undefined
             }
+            disabled={action.disabled}
+            aria-disabled={action.disabled ? 'true' : undefined}
+            title={action.disabled ? action.description ?? 'Acción disponible próximamente.' : undefined}
           >
             {action.label}
           </button>

--- a/frontend-app/src/modules/costos/components/CostosLayout.tsx
+++ b/frontend-app/src/modules/costos/components/CostosLayout.tsx
@@ -16,7 +16,7 @@ import type { BaseCostRecord, CostosRecordMap, CostosSubModulo } from '../types'
 import '../costos.css';
 
 const CostosLayout: React.FC = () => {
-  const { submodule } = useCostosContext();
+  const { submodule, lastSummary } = useCostosContext();
   const effectiveSubmodule = (submodule === 'prorrateo' ? 'gastos' : submodule) as Exclude<CostosSubModulo, 'prorrateo'>;
   const config = costosConfigs[effectiveSubmodule];
   const { query, summary, allocation, trend, formattedSummary } =
@@ -41,6 +41,9 @@ const CostosLayout: React.FC = () => {
   const headerDescription =
     'Calcula, distribuye y consolida costos operativos asegurando trazabilidad entre centros, existencias y asientos.';
 
+  const navigationDisabledMessage =
+    'Disponible cuando se habilite la navegación directa hacia Existencias y Asientos.';
+
   return (
     <div className="costos-module">
       <header className="costos-header">
@@ -52,8 +55,12 @@ const CostosLayout: React.FC = () => {
           <button type="button" className="primary" onClick={() => setDialogOpen(true)}>
             Seguimiento de consolidación
           </button>
-          <button type="button">Ver existencias</button>
-          <button type="button">Ir a asientos</button>
+          <button type="button" disabled title={navigationDisabledMessage}>
+            Ver existencias
+          </button>
+          <button type="button" disabled title={navigationDisabledMessage}>
+            Ir a asientos
+          </button>
         </div>
       </header>
 
@@ -123,7 +130,9 @@ const CostosLayout: React.FC = () => {
         onStart={() => start()}
         onCancel={() => cancel()}
         onRetry={() => retry()}
+        onRefresh={() => query.refetch()}
         process={processState}
+        latestSummary={lastSummary}
       />
     </div>
   );

--- a/frontend-app/src/modules/costos/costos.css
+++ b/frontend-app/src/modules/costos/costos.css
@@ -34,6 +34,11 @@
   flex: 0 0 auto;
 }
 
+.costos-actions button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .costos-tabs {
   display: flex;
   gap: 8px;

--- a/frontend-app/src/modules/costos/pages/config.ts
+++ b/frontend-app/src/modules/costos/pages/config.ts
@@ -15,7 +15,13 @@ export interface CostosModuleConfig {
   detailTitle: string;
   columns: ColumnDefinition[];
   emptyState: string;
-  actions: Array<{ id: string; label: string; intent?: 'primary' | 'secondary' }>;
+  actions: Array<{
+    id: string;
+    label: string;
+    intent?: 'primary' | 'secondary';
+    disabled?: boolean;
+    description?: string;
+  }>;
 }
 
 export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, CostosModuleConfig> = {
@@ -35,9 +41,25 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
       { key: 'accessId', label: 'AccessId', width: '160px' },
     ],
     actions: [
-      { id: 'registrar', label: 'Registrar gasto', intent: 'primary' },
-      { id: 'carga-masiva', label: 'Carga masiva' },
-      { id: 'exportar', label: 'Exportar' },
+      {
+        id: 'registrar',
+        label: 'Registrar gasto',
+        intent: 'primary',
+        disabled: true,
+        description: 'Disponible al conectar el formulario de registro con los servicios reales.',
+      },
+      {
+        id: 'carga-masiva',
+        label: 'Carga masiva',
+        disabled: true,
+        description: 'Se habilitará cuando esté lista la carga masiva del backend.',
+      },
+      {
+        id: 'exportar',
+        label: 'Exportar',
+        disabled: true,
+        description: 'La exportación estará disponible en la integración final.',
+      },
     ],
   },
   depreciaciones: {
@@ -56,8 +78,19 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
       { key: 'accessId', label: 'AccessId', width: '160px' },
     ],
     actions: [
-      { id: 'registrar', label: 'Registrar depreciación', intent: 'primary' },
-      { id: 'carga-masiva', label: 'Carga masiva' },
+      {
+        id: 'registrar',
+        label: 'Registrar depreciación',
+        intent: 'primary',
+        disabled: true,
+        description: 'Pendiente de habilitar junto con el formulario de depreciaciones.',
+      },
+      {
+        id: 'carga-masiva',
+        label: 'Carga masiva',
+        disabled: true,
+        description: 'Se activará con la sincronización oficial de depreciaciones.',
+      },
     ],
   },
   sueldos: {
@@ -74,9 +107,25 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
       { key: 'accessId', label: 'AccessId', width: '160px' },
     ],
     actions: [
-      { id: 'registrar', label: 'Registrar sueldo', intent: 'primary' },
-      { id: 'carga-masiva', label: 'Carga masiva' },
-      { id: 'exportar', label: 'Exportar' },
+      {
+        id: 'registrar',
+        label: 'Registrar sueldo',
+        intent: 'primary',
+        disabled: true,
+        description: 'Disponible cuando se integre el formulario de sueldos.',
+      },
+      {
+        id: 'carga-masiva',
+        label: 'Carga masiva',
+        disabled: true,
+        description: 'Se activará con la carga masiva de nóminas.',
+      },
+      {
+        id: 'exportar',
+        label: 'Exportar',
+        disabled: true,
+        description: 'Las exportaciones estarán disponibles en la versión conectada.',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- disable placeholder quick actions in the app shell with explanatory tooltips until the backend wiring is available
- flag costos table actions and sidebar shortcuts as pending while keeping navigation buttons disabled in the layout
- replace the costos consolidation API calls with a local simulation and update the dialog messaging accordingly

## Testing
- npm run lint *(fails: missing @eslint/js because npm install is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e81db151b48330abbaa0e4560e656b