### PR TITLE
Improve advanced filters styling

### DIFF
--- a/frontend-app/src/modules/reportes/components/AdvancedFilters.tsx
+++ b/frontend-app/src/modules/reportes/components/AdvancedFilters.tsx
@@ -63,55 +63,66 @@ const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({ descriptors }) => {
 
   return (
     <aside className="reportes-module__filters">
-      <header>
+      <header className="reportes-filters__header">
         <h2>Filtros avanzados</h2>
         <p>Configura los criterios de consulta y comparte la vista con tu equipo.</p>
       </header>
 
-      <label>
-        <span>{descriptorMap.get('periodo')?.label ?? 'Periodo (mes)'}</span>
-        <input
-          type="month"
-          value={filters.periodo ? filters.periodo.slice(0, 7) : ''}
-          onChange={handlePeriodoChange}
-          aria-describedby="periodo-helper"
-        />
-        {descriptorMap.get('periodo')?.helper && (
-          <small id="periodo-helper">{descriptorMap.get('periodo')?.helper}</small>
-        )}
-      </label>
+      <div className="reportes-filter-fields" role="group" aria-label="Filtros principales">
+        <label className="reportes-filter-field">
+          <span className="reportes-filter-label">{descriptorMap.get('periodo')?.label ?? 'Periodo (mes)'}</span>
+          <input
+            className="reportes-filter-input"
+            type="month"
+            value={filters.periodo ? filters.periodo.slice(0, 7) : ''}
+            onChange={handlePeriodoChange}
+            aria-describedby="periodo-helper"
+          />
+          {descriptorMap.get('periodo')?.helper && (
+            <small id="periodo-helper" className="reportes-filter-helper">
+              {descriptorMap.get('periodo')?.helper}
+            </small>
+          )}
+        </label>
 
-      <label>
-        <span>{descriptorMap.get('producto')?.label ?? 'Producto'}</span>
-        <input
-          type="text"
-          value={filters.producto ?? ''}
-          onChange={handleProductoChange}
-          placeholder="Nombre o clave de producto"
-        />
-      </label>
+        <label className="reportes-filter-field">
+          <span className="reportes-filter-label">{descriptorMap.get('producto')?.label ?? 'Producto'}</span>
+          <input
+            className="reportes-filter-input"
+            type="text"
+            value={filters.producto ?? ''}
+            onChange={handleProductoChange}
+            placeholder="Nombre o clave de producto"
+          />
+        </label>
 
-      <label>
-        <span>{descriptorMap.get('centro')?.label ?? 'Centro'}</span>
-        <input
-          type="number"
-          min={0}
-          value={filters.centro ?? ''}
-          onChange={handleCentroChange}
-          placeholder="ID de centro"
-        />
-      </label>
+        <label className="reportes-filter-field">
+          <span className="reportes-filter-label">{descriptorMap.get('centro')?.label ?? 'Centro'}</span>
+          <input
+            className="reportes-filter-input"
+            type="number"
+            min={0}
+            value={filters.centro ?? ''}
+            onChange={handleCentroChange}
+            placeholder="ID de centro"
+          />
+        </label>
 
-      <label>
-        <span>Formato preferido</span>
-        <select value={filters.format ?? 'json'} onChange={handleFormatChange}>
-          {formatOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </label>
+        <label className="reportes-filter-field">
+          <span className="reportes-filter-label">Formato preferido</span>
+          <select
+            className="reportes-filter-input reportes-filter-select"
+            value={filters.format ?? 'json'}
+            onChange={handleFormatChange}
+          >
+            {formatOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
 
       <div className="reportes-export-bar" role="group" aria-label="Acciones de filtros">
         <button type="button" onClick={resetFilters}>
@@ -128,14 +139,15 @@ const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({ descriptors }) => {
       </div>
 
       <section className="reportes-presets" aria-label="Presets guardados">
-        <header>
+        <header className="reportes-presets__header">
           <h3>Presets</h3>
           <p>Guarda combinaciones frecuentes para reutilizarlas.</p>
         </header>
-        <div>
-          <label>
-            <span>Nombre del preset</span>
+        <div className="reportes-presets__controls">
+          <label className="reportes-filter-field reportes-presets__field">
+            <span className="reportes-filter-label">Nombre del preset</span>
             <input
+              className="reportes-filter-input"
               type="text"
               value={presetName}
               onChange={(event) => setPresetName(event.target.value)}

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -20,6 +20,91 @@
   margin: 0;
 }
 
+.reportes-filters__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.reportes-filters__header p {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.9);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.reportes-filter-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reportes-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  position: relative;
+}
+
+.reportes-filter-field:hover {
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.reportes-filter-field:focus-within {
+  border-color: rgba(125, 211, 252, 0.9);
+  box-shadow: 0 10px 30px rgba(125, 211, 252, 0.15);
+  transform: translateY(-2px);
+}
+
+.reportes-filter-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.reportes-filter-input {
+  background: rgba(15, 23, 42, 0.3);
+  border: none;
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  color: #f8fafc;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reportes-filter-input:focus {
+  outline: none;
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.6);
+}
+
+.reportes-filter-input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.reportes-filter-select {
+  appearance: none;
+  padding-right: 2.5rem;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(148, 163, 184, 0.7) 50%),
+    linear-gradient(135deg, rgba(148, 163, 184, 0.7) 50%, transparent 50%);
+  background-position: calc(100% - 1.3rem) 50%, calc(100% - 1rem) 50%;
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.reportes-filter-helper {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
 .reportes-module__content {
   display: flex;
   flex-direction: column;
@@ -174,6 +259,7 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
+  margin-top: 0.5rem;
 }
 
 .reportes-export-bar button {
@@ -199,6 +285,52 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.reportes-presets__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.reportes-presets__header p {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.9);
+  font-size: 0.9rem;
+}
+
+.reportes-presets__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reportes-presets__controls > button {
+  align-self: flex-end;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #22d3ee, #818cf8);
+  color: #0f172a;
+  padding: 0.6rem 1.25rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reportes-presets__controls > button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.reportes-presets__controls > button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(129, 140, 248, 0.25);
+}
+
+.reportes-presets__field {
+  margin: 0;
 }
 
 .reportes-presets__list {
@@ -248,5 +380,9 @@
 
   .reportes-module__filters {
     order: 2;
+  }
+
+  .reportes-presets__controls {
+    gap: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- redesign advanced filters form structure for better grouping and readability
- introduce new filter field styles and presets controls to align with refreshed visual language

## Testing
- npm run lint *(fails: missing @eslint/js package because registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e96c385bd48330825369254dcc7ba4