### PR TITLE
Update sueldos table columns and mapping

### DIFF
--- a/frontend-app/src/modules/costos/pages/config.ts
+++ b/frontend-app/src/modules/costos/pages/config.ts
@@ -99,12 +99,22 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
     detailTitle: 'Detalle de sueldo',
     emptyState: 'No hay sueldos registrados con los filtros actuales.',
     columns: [
-      { key: 'fechaSueldo', label: 'Fecha de sueldo', width: '120px' },
-      { key: 'centro', label: 'Centro', width: '100px' },
-      { key: 'nroEmpleado', label: 'Empleado', width: '120px' },
-      { key: 'sueldoTotal', label: 'Sueldo total', width: '140px', align: 'right' },
-      { key: 'esGastoDelPeriodo', label: 'Del periodo', width: '120px', align: 'center' },
-      { key: 'accessId', label: 'AccessId', width: '160px' },
+      { key: 'fechaSueldo', label: 'FECHA', width: '120px' },
+      { key: 'centro', label: 'CENTRO', width: '120px' },
+      {
+        key: 'nroEmpleado',
+        label: 'COD EMPLEADO',
+        width: '140px',
+        render: (value) => {
+          if (value === undefined || value === null) {
+            return '—';
+          }
+          return String(value);
+        },
+      },
+      { key: 'empleadoNombre', label: 'EMPLEADO', width: '220px' },
+      { key: 'sueldoTotal', label: 'SUELDO TOTAL', width: '160px', align: 'right' },
+      { key: 'esGastoDelPeriodo', label: 'DEL PERIODO', width: '140px', align: 'center' },
     ],
     actions: [
       {

--- a/frontend-app/src/modules/costos/types.ts
+++ b/frontend-app/src/modules/costos/types.ts
@@ -43,6 +43,7 @@ export interface SueldoRecord extends BaseCostRecord {
   nroEmpleado: number;
   fechaSueldo: string;
   sueldoTotal: number;
+  empleadoNombre?: string;
 }
 
 export type CostosRecordMap = {

--- a/frontend-app/src/modules/costos/utils/transformers.ts
+++ b/frontend-app/src/modules/costos/utils/transformers.ts
@@ -139,13 +139,20 @@ export function mapDepreciacionRecord(raw: RawRecord): DepreciacionRecord {
 export function mapSueldoRecord(raw: RawRecord): SueldoRecord {
   const centro = ensureString(raw.centro ?? raw.Centro) ?? '0';
   const calculationDate = ensureIsoDate(raw.calculationDate ?? raw.fechaCalculo ?? raw.FechaCalculo);
+  const rawEmployeeNumber = raw.nroEmpleado ?? raw.NroEmpleado ?? raw.empleado ?? 0;
+  const parsedEmployeeNumber =
+    typeof rawEmployeeNumber === 'number'
+      ? rawEmployeeNumber
+      : Number.parseInt(String(rawEmployeeNumber).replace(/[^0-9]/g, ''), 10);
+
   return {
     id: ensureId(raw),
     centro,
     calculationDate,
-    nroEmpleado: Number.parseInt(String(raw.nroEmpleado ?? raw.NroEmpleado ?? raw.empleado ?? 0), 10),
+    nroEmpleado: Number.isNaN(parsedEmployeeNumber) ? 0 : parsedEmployeeNumber,
     fechaSueldo: ensureIsoDate(raw.fechaSueldo ?? raw.FechaSueldo ?? raw.fecha),
     sueldoTotal: ensureNumber(raw.sueldoTotal ?? raw.SueldoTotal ?? raw.monto ?? raw.Monto),
+    empleadoNombre: ensureString(raw.nombre ?? raw.Nombre ?? raw.empleadoNombre ?? raw.EmpleadoNombre),
     createdAt: raw.createdAt ? ensureIsoDate(raw.createdAt) : undefined,
     createdBy: ensureString(raw.createdBy ?? raw.usuarioAlta),
     updatedAt: raw.updatedAt ? ensureIsoDate(raw.updatedAt) : undefined,


### PR DESCRIPTION
## Summary
- update the sueldos table configuration to show FECHA, CENTRO, COD EMPLEADO, EMPLEADO, SUELDO TOTAL y DEL PERIODO and drop the AccessId column
- normalize employee numbers and expose employee names when mapping sueldo records so values align with the headers

## Testing
- npm install *(fails: 403 Forbidden when downloading recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68e9927012a083308903c87f93704523