### PR TITLE
Align daily operation table styling with production centers

### DIFF
--- a/frontend-app/src/modules/operacion/components/CloseDayBanner.tsx
+++ b/frontend-app/src/modules/operacion/components/CloseDayBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatDate } from '../utils/format';
 
 interface Props {
   closeReason?: string;
@@ -7,11 +8,25 @@ interface Props {
 }
 
 const CloseDayBanner: React.FC<Props> = ({ closeReason, expectedUnlockAt, responsable }) => {
+  let unlockText: string | null = null;
+  if (expectedUnlockAt) {
+    const baseDate = new Date(expectedUnlockAt);
+    if (Number.isNaN(baseDate.getTime())) {
+      unlockText = expectedUnlockAt;
+    } else {
+      const time = baseDate.toLocaleTimeString('es-MX', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      unlockText = `${formatDate(expectedUnlockAt)} ${time}`;
+    }
+  }
+
   return (
     <div className="close-day-banner" role="alert">
       <strong>Captura bloqueada</strong>
       <span>{closeReason ?? 'El backend reportó un cierre pendiente.'}</span>
-      {expectedUnlockAt && <span>Desbloqueo estimado: {new Date(expectedUnlockAt).toLocaleString('es-MX')}</span>}
+      {unlockText && <span>Desbloqueo estimado: {unlockText}</span>}
       {responsable && <span>Responsable asignado: {responsable}</span>}
     </div>
   );

--- a/frontend-app/src/modules/operacion/components/OperacionFilterBar.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionFilterBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useOperacionFilters } from '../hooks/useOperacionFilters';
-import { useOperacionContext } from '../context/OperacionContext';
 import type { VistaModuloConfig } from '../types';
 
 interface Props {
@@ -8,8 +7,7 @@ interface Props {
 }
 
 const OperacionFilterBar: React.FC<Props> = ({ config }) => {
-  const { modulo, setModulo, filtros, updateFiltros, resetFiltros } = useOperacionFilters();
-  const { vistas, saveVista, deleteVista, shareVista } = useOperacionContext();
+  const { modulo, setModulo, filtros, updateFiltros } = useOperacionFilters();
 
   const handleChange = (field: keyof typeof filtros) => (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     updateFiltros({ [field]: event.target.value } as never);
@@ -17,29 +15,6 @@ const OperacionFilterBar: React.FC<Props> = ({ config }) => {
 
   const handleDate = (field: 'desde' | 'hasta') => (event: React.ChangeEvent<HTMLInputElement>) => {
     updateFiltros({ rango: { ...(filtros.rango ?? { desde: filtros.calculationDate, hasta: filtros.calculationDate }), [field]: event.target.value } });
-  };
-
-  const handleSaveView = () => {
-    const nombre = prompt('Nombre de la vista');
-    if (!nombre) return;
-    saveVista({
-      nombre,
-      modulo,
-      filtros,
-      owner: 'coordinador.01',
-      rolesVisibles: ['coordinador', 'analista'],
-    });
-  };
-
-  const handleShare = (id: string) => {
-    const enlace = shareVista(id);
-    if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(enlace).catch(() => {
-        alert(`Enlace generado: ${enlace}`);
-      });
-    } else {
-      alert(`Enlace generado: ${enlace}`);
-    }
   };
 
   return (
@@ -106,44 +81,6 @@ const OperacionFilterBar: React.FC<Props> = ({ config }) => {
           <input type="date" value={filtros.rango.hasta} onChange={handleDate('hasta')} />
         </label>
       )}
-      <div className="saved-views">
-        <select
-          aria-label="Vistas guardadas"
-          onChange={(event) => {
-            const id = event.target.value;
-            if (!id) return;
-            const vista = vistas.find((item) => item.id === id);
-            if (!vista) return;
-            setModulo(vista.modulo);
-            updateFiltros(vista.filtros);
-          }}
-        >
-          <option value="">Vistas guardadas</option>
-          {vistas
-            .filter((vista) => vista.modulo === modulo)
-            .map((vista) => (
-              <option key={vista.id} value={vista.id}>
-                {vista.nombre}
-              </option>
-            ))}
-        </select>
-        <button type="button" className="primary" onClick={handleSaveView}>
-          Guardar vista
-        </button>
-        {vistas.length > 0 && (
-          <button type="button" className="secondary" onClick={() => handleShare(vistas[0].id)}>
-            Compartir primera vista
-          </button>
-        )}
-        {vistas.length > 0 && (
-          <button type="button" className="secondary" onClick={() => deleteVista(vistas[0].id)}>
-            Eliminar primera vista
-          </button>
-        )}
-        <button type="button" className="ghost" onClick={resetFiltros}>
-          Restablecer filtros
-        </button>
-      </div>
     </section>
   );
 };

--- a/frontend-app/src/modules/operacion/components/ResumenContextual.tsx
+++ b/frontend-app/src/modules/operacion/components/ResumenContextual.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { ResumenContextual } from '../types';
+import { formatDate } from '../utils/format';
 import SyncStatusBadge from './SyncStatusBadge';
 import CloseDayBanner from './CloseDayBanner';
 
@@ -14,7 +15,9 @@ const ResumenContextualSection: React.FC<Props> = ({ resumen, totalRegistros, la
     <div className="operacion-resumen" role="status" aria-live="polite">
       <div>
         <strong>{resumen?.centro ?? 'Centro sin asignar'}</strong>
-        <div>Fecha cálculo: {resumen?.calculationDate ?? 'N/D'}</div>
+        <div>
+          Fecha cálculo: {resumen?.calculationDate ? formatDate(resumen.calculationDate) : 'N/D'}
+        </div>
         {resumen?.responsable && <div>Responsable: {resumen.responsable}</div>}
       </div>
       <div>

--- a/frontend-app/src/modules/operacion/operacion.css
+++ b/frontend-app/src/modules/operacion/operacion.css
@@ -52,54 +52,42 @@
   background: #fff;
 }
 
-.operacion-filtros .saved-views {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  grid-column: 1 / -1;
-}
-
-.operacion-filtros .saved-views select {
-  min-width: 200px;
-  flex: 1 1 220px;
-}
-
-.operacion-filtros .saved-views button {
-  flex: 0 0 auto;
-  white-space: nowrap;
-}
-
 .operacion-datagrid {
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: inset 0 0 0 1px #e2e8f0;
   display: flex;
   flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-outline);
+  border-radius: 16px;
+  box-shadow: var(--shadow-level-1);
 }
 
 .operacion-datagrid--placeholder {
+  display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 1rem;
   min-height: 220px;
   text-align: center;
-  gap: 0.75rem;
+  padding: 32px;
 }
 
 .operacion-datagrid--placeholder p {
   margin: 0;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .operacion-datagrid--placeholder small {
-  color: #64748b;
+  color: rgba(71, 85, 105, 0.75);
 }
 
 .operacion-datagrid--placeholder .spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid #cbd5f5;
-  border-top-color: #2563eb;
+  border: 3px solid rgba(20, 94, 168, 0.2);
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: spin 0.9s linear infinite;
 }
@@ -110,27 +98,115 @@
   }
 }
 
-.operacion-datagrid table {
+.operacion-datagrid__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  border-bottom: 1px solid var(--color-outline);
+  padding-bottom: 12px;
+}
+
+.operacion-datagrid__header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.operacion-datagrid__header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-text-primary);
+}
+
+.operacion-datagrid__header p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.operacion-datagrid__table-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.operacion-datagrid__scroll {
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  overflow: auto;
+}
+
+.operacion-datagrid__table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   min-width: 640px;
 }
 
-.operacion-datagrid thead {
-  background: #f1f5f9;
-  color: #0f172a;
+.operacion-datagrid__table thead th {
+  background: rgba(20, 94, 168, 0.08);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-outline);
 }
 
-.operacion-datagrid th,
-.operacion-datagrid td {
-  padding: 0.65rem 0.75rem;
-  border-bottom: 1px solid #e2e8f0;
-  text-align: left;
+.operacion-datagrid__selection {
+  width: 52px;
+  text-align: center;
 }
 
-.operacion-datagrid tbody tr:hover {
-  background: #f8fafc;
+.operacion-datagrid__table tbody tr {
+  transition: background-color 0.2s ease;
+}
+
+.operacion-datagrid__table tbody tr:hover {
+  background: rgba(20, 94, 168, 0.06);
+}
+
+.operacion-datagrid__cell {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-outline);
+  color: var(--color-text-primary);
+  vertical-align: middle;
+}
+
+.operacion-datagrid__cell--selection {
+  text-align: center;
+}
+
+.operacion-datagrid__cell--nowrap {
+  white-space: nowrap;
+}
+
+.operacion-datagrid__cell input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+}
+
+.operacion-datagrid .table-pagination {
+  margin: 0;
+  padding: 0;
+}
+
+.operacion-datagrid .table-pagination__summary {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.operacion-datagrid .table-pagination__page-size {
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 500;
+}
+
+.operacion-datagrid .table-pagination__page-indicator {
+  font-size: 0.85rem;
 }
 
 .operacion-toolbar {

--- a/frontend-app/src/modules/operacion/utils/format.ts
+++ b/frontend-app/src/modules/operacion/utils/format.ts
@@ -6,7 +6,18 @@ export function formatNumber(value: number, decimals = 2): string {
 }
 
 export function formatDate(value: string): string {
+  if (!value) return '—';
+  const isoMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) {
+    const [, year, month, day] = isoMatch;
+    return `${day}/${month}/${year}`;
+  }
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleDateString('es-MX');
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${day}/${month}/${year}`;
 }


### PR DESCRIPTION
## Summary
- restyled the daily operation data grid to reuse the production center table layout and streamline selection controls
- removed saved view management controls from the filter bar for a cleaner filter experience
- standardized date formatting across operation summaries, tables, and alerts to the dd/mm/aaaa format

## Testing
- npm --prefix frontend-herbal/frontend-app install *(fails: 403 Forbidden fetching recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68e995cc943083308f6f4847ffd05b88