### PR TITLE
Alinear tablas de costos con operación diaria

### DIFF
--- a/frontend-app/src/modules/costos/components/CostosDataTable.tsx
+++ b/frontend-app/src/modules/costos/components/CostosDataTable.tsx
@@ -3,6 +3,7 @@ import { formatCurrency } from '@/lib/formatters';
 import TablePagination from '@/components/TablePagination';
 import usePagination from '@/lib/usePagination';
 import type {
+  BaseCostRecord,
   CostosRecordMap,
   CostosSubModulo,
   DepreciacionRecord,
@@ -10,6 +11,7 @@ import type {
   SueldoRecord,
 } from '../types';
 import type { ColumnDefinition, CostosModuleConfig } from '../pages/config';
+import '../../operacion/operacion.css';
 import '../costos.css';
 
 interface CostosDataTableProps<K extends Exclude<CostosSubModulo, 'prorrateo'>> {
@@ -22,6 +24,29 @@ interface CostosDataTableProps<K extends Exclude<CostosSubModulo, 'prorrateo'>> 
   onSelect: (record: CostosRecordMap[K] | null) => void;
   selectedId: string | null;
   onAction?: (actionId: string) => void;
+}
+
+function formatDate(value: string | undefined | null): string {
+  if (!value) {
+    return '—';
+  }
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (match) {
+    const [, year, month, day] = match;
+    return `${day}/${month}/${year}`;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString('es-MX', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
 }
 
 function getCellValue(
@@ -44,7 +69,7 @@ function getCellValue(
   }
   if (typeof value === 'string') {
     if (column.key.toLowerCase().includes('fecha')) {
-      return new Date(value).toLocaleDateString('es-MX');
+      return formatDate(value);
     }
     return value;
   }
@@ -52,6 +77,13 @@ function getCellValue(
     return '—';
   }
   return JSON.stringify(value);
+}
+
+function buildTraceLabel(record: BaseCostRecord): string {
+  const source = record.source === 'import' ? 'import' : 'manual';
+  const date = formatDate(record.createdAt ?? record.calculationDate);
+  const actor = record.createdBy ? ` · ${record.createdBy}` : '';
+  return `${source} · ${date}${actor}`;
 }
 
 const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
@@ -66,102 +98,140 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
   onAction,
 }: CostosDataTableProps<K>) => {
   const pagination = usePagination(records, {
-    initialPageSize: 10,
-    pageSizeOptions: [10, 25, 50],
+    initialPageSize: 25,
+    pageSizeOptions: [25, 50, 100],
   });
 
   const pageRecords = pagination.items;
 
   if (loading) {
-    return <div className="costos-empty-state">Cargando registros de costos…</div>;
+    return (
+      <div className="operacion-datagrid operacion-datagrid--placeholder" role="status" aria-live="polite">
+        <div className="spinner" aria-hidden="true" />
+        <p>Cargando registros de {config.title.toLowerCase()}…</p>
+      </div>
+    );
   }
 
   if (error) {
     return (
-      <div className="costos-empty-state" role="alert">
-        <p>No se pudieron cargar los registros. Intenta nuevamente.</p>
+      <div className="operacion-datagrid operacion-datagrid--placeholder" role="alert">
+        <p>Ocurrió un problema al consultar los datos.</p>
+        <small>No se pudieron cargar los registros. Intenta nuevamente.</small>
         <button type="button" className="primary" onClick={onRetry}>
-          Reintentar
+          Reintentar consulta
         </button>
       </div>
     );
   }
 
   if (records.length === 0) {
-    return <div className="costos-empty-state">{config.emptyState}</div>;
+    return (
+      <div className="operacion-datagrid operacion-datagrid--placeholder">
+        <p>{config.emptyState}</p>
+        <button type="button" className="secondary" onClick={() => onSelect(null)}>
+          Limpiar selección
+        </button>
+      </div>
+    );
   }
 
   return (
-    <div className="costos-card" role="region" aria-live="polite">
-      <div className="costos-toolbar">
-        <div>
+    <section className="operacion-datagrid costos-datagrid" aria-label={`Listado de ${config.title.toLowerCase()}`}>
+      <header className="operacion-datagrid__header">
+        <div className="operacion-datagrid__header-text">
           <h2>{config.title}</h2>
-          <p className="costos-metadata">{config.description}</p>
+          <p>{config.description}</p>
         </div>
-      </div>
-      <div className="costos-actions" role="group" aria-label="Acciones rápidas">
-        {config.actions.map((action) => (
-          <button
-            key={action.id}
-            type="button"
-            className={
-              action.intent === 'primary' ? 'primary' : action.intent === 'secondary' ? 'secondary' : undefined
-            }
-            disabled={action.disabled}
-            aria-disabled={action.disabled ? 'true' : undefined}
-            title={action.disabled ? action.description ?? 'Acción disponible próximamente.' : undefined}
-            onClick={() => {
-              if (action.disabled) {
-                return;
-              }
-              onAction?.(action.id);
-            }}
-          >
-            {action.label}
+        <div className="costos-datagrid__header-actions">
+          <button type="button" className="secondary" onClick={() => onSelect(null)}>
+            Limpiar selección
           </button>
-        ))}
-      </div>
-      <div className="table-container">
-        <table className="costos-table">
-          <thead>
-            <tr>
-              {config.columns.map((column) => (
-                <th key={column.key} style={{ width: column.width }} scope="col">
-                  {column.label}
+        </div>
+      </header>
+
+      {config.actions.length > 0 && (
+        <div className="costos-datagrid__actions" role="group" aria-label="Acciones rápidas">
+          {config.actions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              className={
+                action.intent === 'primary' ? 'primary' : action.intent === 'secondary' ? 'secondary' : 'ghost'
+              }
+              disabled={action.disabled}
+              aria-disabled={action.disabled ? 'true' : undefined}
+              title={action.disabled ? action.description ?? 'Acción disponible próximamente.' : undefined}
+              onClick={() => {
+                if (action.disabled) {
+                  return;
+                }
+                onAction?.(action.id);
+              }}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="operacion-datagrid__table-container">
+        <div className="operacion-datagrid__scroll">
+          <table className="operacion-datagrid__table">
+            <thead>
+              <tr>
+                <th className="operacion-datagrid__selection">
+                  <span className="sr-only">Seleccionar</span>
                 </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {pageRecords.map((record) => (
-              <tr
-                key={record.id}
-                data-selected={record.id === selectedId}
-                onClick={() => onSelect(record)}
-              >
                 {config.columns.map((column) => (
-                  <td key={column.key} style={{ textAlign: column.align ?? 'left' }}>
-                    {getCellValue(record, column, currency)}
-                  </td>
+                  <th key={column.key} style={{ width: column.width }} scope="col">
+                    {column.label}
+                  </th>
                 ))}
+                <th scope="col">Trazabilidad</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {pageRecords.map((record) => {
+                const isSelected = record.id === selectedId;
+                return (
+                  <tr key={record.id} data-selected={isSelected ? 'true' : 'false'}>
+                    <td className="operacion-datagrid__cell operacion-datagrid__cell--selection">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => onSelect(isSelected ? null : record)}
+                        aria-label={`Seleccionar registro ${record.id}`}
+                      />
+                    </td>
+                    {config.columns.map((column) => (
+                      <td key={`${record.id}-${column.key}`} className="operacion-datagrid__cell" style={{ textAlign: column.align ?? 'left' }}>
+                        {getCellValue(record, column, currency)}
+                      </td>
+                    ))}
+                    <td className="operacion-datagrid__cell operacion-datagrid__cell--nowrap">
+                      <span className="costos-datagrid__trace operacion-chip sync">{buildTraceLabel(record)}</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination
+          page={pagination.page}
+          totalPages={pagination.totalPages}
+          from={pagination.from}
+          to={pagination.to}
+          totalItems={pagination.totalItems}
+          pageSize={pagination.pageSize}
+          pageSizeOptions={pagination.pageSizeOptions}
+          onPageChange={pagination.setPage}
+          onPageSizeChange={pagination.setPageSize}
+          label={`Paginación de ${config.title}`}
+        />
       </div>
-      <TablePagination
-        page={pagination.page}
-        totalPages={pagination.totalPages}
-        from={pagination.from}
-        to={pagination.to}
-        totalItems={pagination.totalItems}
-        pageSize={pagination.pageSize}
-        pageSizeOptions={pagination.pageSizeOptions}
-        onPageChange={pagination.setPage}
-        onPageSizeChange={pagination.setPageSize}
-        label={`Paginación de ${config.title}`}
-      />
-    </div>
+    </section>
   );
 };
 

--- a/frontend-app/src/modules/costos/costos.css
+++ b/frontend-app/src/modules/costos/costos.css
@@ -256,32 +256,33 @@
   height: 120px;
 }
 
-.costos-table {
-  width: 100%;
-  border-collapse: collapse;
+.costos-datagrid {
+  position: relative;
 }
 
-.costos-table thead {
-  background: rgba(20, 94, 168, 0.08);
-  color: var(--color-text-secondary);
+.costos-datagrid__header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.costos-datagrid__actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.costos-datagrid__actions button {
+  min-width: 140px;
+}
+
+.costos-datagrid__trace {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
   text-transform: uppercase;
-  font-size: 0.75rem;
-}
-
-.costos-table th,
-.costos-table td {
-  padding: 12px 16px;
-  text-align: left;
-  border-bottom: 1px solid var(--color-outline);
-  background: var(--color-surface);
-}
-
-.costos-table tbody tr:hover {
-  background: rgba(20, 94, 168, 0.08);
-}
-
-.costos-table tbody tr[data-selected='true'] {
-  background: rgba(20, 94, 168, 0.16);
+  letter-spacing: 0.04em;
 }
 
 .costos-empty-state {

--- a/frontend-app/src/modules/costos/pages/config.ts
+++ b/frontend-app/src/modules/costos/pages/config.ts
@@ -38,7 +38,6 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
       { key: 'tipo', label: 'Tipo', width: '160px' },
       { key: 'monto', label: 'Monto', width: '140px', align: 'right' },
       { key: 'esGastoDelPeriodo', label: 'Del periodo', width: '120px', align: 'center' },
-      { key: 'accessId', label: 'AccessId', width: '160px' },
     ],
     actions: [
       {
@@ -75,7 +74,6 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
       { key: 'depreMensual', label: 'Depreciación mensual', width: '160px', align: 'right' },
       { key: 'vidaUtil', label: 'Vida útil', width: '120px', align: 'right' },
       { key: 'valorUso', label: 'Valor en uso', width: '140px', align: 'right' },
-      { key: 'accessId', label: 'AccessId', width: '160px' },
     ],
     actions: [
       {


### PR DESCRIPTION
## Summary
- rework CostosDataTable to reuse the operación diaria datagrid layout with selección, paginación y trazabilidad
- ajustar los estilos de costos para el nuevo datagrid y ocultar columnas innecesarias
- eliminar el campo AccessId de las configuraciones de columnas para gastos y depreciaciones

## Testing
- npm run lint *(falla: falta @eslint/js por dependencias no instaladas)*
- npm install *(falla: el registro npm devuelve 403 al solicitar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68e998aeaa9c8330bac450ecd11165cc