### PR TITLE
Switch report period filter to full date input

### DIFF
--- a/frontend-app/src/modules/reportes/components/AdvancedFilters.tsx
+++ b/frontend-app/src/modules/reportes/components/AdvancedFilters.tsx
@@ -70,11 +70,11 @@ const AdvancedFilters: React.FC<AdvancedFiltersProps> = ({ descriptors }) => {
 
       <div className="reportes-filter-fields" role="group" aria-label="Filtros principales">
         <label className="reportes-filter-field">
-          <span className="reportes-filter-label">{descriptorMap.get('periodo')?.label ?? 'Periodo (mes)'}</span>
+          <span className="reportes-filter-label">{descriptorMap.get('periodo')?.label ?? 'Periodo (fecha)'}</span>
           <input
             className="reportes-filter-input"
-            type="month"
-            value={filters.periodo ? filters.periodo.slice(0, 7) : ''}
+            type="date"
+            value={filters.periodo ?? ''}
             onChange={handlePeriodoChange}
             aria-describedby="periodo-helper"
           />

--- a/frontend-app/src/modules/reportes/index.tsx
+++ b/frontend-app/src/modules/reportes/index.tsx
@@ -15,7 +15,7 @@ const categoryComponentMap: Record<ReportCategory, React.ComponentType> = {
 };
 
 const filterDescriptors: Array<{ id: keyof ReportFilters; label: string; helper?: string }> = [
-  { id: 'periodo', label: 'Periodo (mes)', helper: 'Selecciona el mes de análisis (formato AAAA-MM).' },
+  { id: 'periodo', label: 'Periodo (fecha)', helper: 'Selecciona la fecha de análisis (formato AAAA-MM-DD).' },
   { id: 'producto', label: 'Producto', helper: 'Filtra por nombre o clave de producto.' },
   { id: 'centro', label: 'Centro de costos', helper: 'Requiere seleccionar un periodo para habilitarse.' },
   { id: 'format', label: 'Formato preferido' },


### PR DESCRIPTION
## Summary
- change the report period filter input to request a full date value
- refresh the default label and helper copy to highlight the AAAA-MM-DD requirement

## Testing
- npm test *(fails: missing npm dependencies because installation is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e99952902083308c5420bfe69f311a