### PR TITLE
Fix alignment of catalog table headers

### DIFF
--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -311,6 +311,7 @@ textarea.config-input {
   font-weight: 700;
   padding: 14px 16px;
   border-bottom: 1px solid var(--color-outline);
+  text-align: left;
 }
 
 .config-table tbody tr {
@@ -325,6 +326,7 @@ textarea.config-input {
   padding: 14px 16px;
   border-bottom: 1px solid var(--color-outline);
   color: var(--color-text-primary);
+  text-align: left;
 }
 
 .config-table__pagination {


### PR DESCRIPTION
## Summary
- left-align catalog table headers and cells so column titles line up with their values

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed9fc6b15c8330bc4037583f60e4cc