### PR TITLE
Alinear estilos de los campos en importaciones

### DIFF
--- a/frontend-app/src/modules/importaciones/importaciones.css
+++ b/frontend-app/src/modules/importaciones/importaciones.css
@@ -130,25 +130,59 @@
 }
 
 .importaciones-form__fields {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: 1rem;
-  align-items: flex-end;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  align-items: end;
 }
 
 .importaciones-field {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  color: #334155;
+  gap: 0.4rem;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
-.importaciones-field input[type='date'] {
-  border: 1px solid #cbd5e1;
+.importaciones-field span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.importaciones-field input {
+  border: 1px solid var(--color-outline);
   border-radius: 10px;
-  padding: 0.45rem 0.6rem;
+  padding: 0.55rem 0.75rem;
   font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  background: #fff;
+  text-transform: none;
+  letter-spacing: normal;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.importaciones-field input::placeholder {
+  color: var(--color-text-secondary);
+  opacity: 0.7;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.importaciones-field input:focus {
+  outline: none;
+  border-color: rgba(20, 94, 168, 0.55);
+  box-shadow: 0 0 0 3px rgba(20, 94, 168, 0.12);
+}
+
+.importaciones-form__fields > .importaciones-button {
+  justify-self: start;
+  align-self: end;
+  padding: 0.65rem 1.3rem;
 }
 
 .importaciones-button {


### PR DESCRIPTION
## Summary
- ajusta la disposición de los campos de carga de archivos para alinearlos al layout de formularios del sistema
- aplica tipografía, colores y estados de foco consistentes con la sección de Costos y consolidaciones

## Testing
- npm install *(falla: 403 Forbidden al descargar recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68eda2b339e083308397d3bf475b400f