### PR TITLE
Fix configuration form action button sizing

### DIFF
--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -192,6 +192,8 @@ textarea.config-input {
   display: flex;
   gap: 12px;
   justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .catalog-view {


### PR DESCRIPTION
## Summary
- update the configuration form action container to center-align buttons
- allow action buttons to wrap so they retain their natural size like the catalog actions

## Testing
- not run (npm install fails: npm registry returns 403)


------
https://chatgpt.com/codex/tasks/task_e_68eda3135838833093ccf06adbf19629