### PR TITLE
Show tablaOrigen as gasto concept

### DIFF
--- a/frontend-app/src/modules/costos/__tests__/transformers.test.ts
+++ b/frontend-app/src/modules/costos/__tests__/transformers.test.ts
@@ -18,6 +18,7 @@ test('mapGastoRecord normaliza montos y fechas', () => {
     concepto: 'Reparación de caldera',
     tipo: 'Mantenimiento',
     esGastoDelPeriodo: 'true',
+    tablaOrigen: 'GastosDeAdministracion',
   });
 
   assert.equal(record.id, '123');
@@ -25,6 +26,7 @@ test('mapGastoRecord normaliza montos y fechas', () => {
   assert.equal(record.monto, 8420.75);
   assert.equal(new Date(record.fecha).toISOString().startsWith('2024-05-10'), true);
   assert.equal(record.esGastoDelPeriodo, true);
+  assert.equal(record.concepto, 'GastosDeAdministracion');
 });
 
 test('mapDepreciacionRecord asigna valores por defecto', () => {

--- a/frontend-app/src/modules/costos/utils/transformers.ts
+++ b/frontend-app/src/modules/costos/utils/transformers.ts
@@ -93,15 +93,17 @@ export function mapGastoRecord(raw: RawRecord): GastoRecord {
   const monto = ensureNumber(raw.monto ?? raw.Monto ?? raw.importe ?? raw.Importe);
   const centro = ensureString(raw.centro ?? raw.Centro) ?? '0';
   const calculationDate = ensureIsoDate(raw.calculationDate ?? raw.fechaCalculo ?? raw.FechaCalculo);
+  const tablaOrigen = ensureString(raw.tablaOrigen ?? raw.origen);
+  const concepto = tablaOrigen ?? ensureString(raw.concepto ?? raw.Concepto ?? raw.descripcion);
   return {
     id: ensureId(raw),
     centro,
     calculationDate,
     fecha: ensureIsoDate(raw.fecha ?? raw.Fecha ?? raw.fechaGasto),
-    concepto: ensureString(raw.concepto ?? raw.Concepto ?? raw.descripcion),
+    concepto,
     monto,
     tipo: ensureString(raw.tipo ?? raw.Tipo ?? raw.clasificacion) ?? undefined,
-    tablaOrigen: ensureString(raw.tablaOrigen ?? raw.origen),
+    tablaOrigen,
     detalle: (raw.detalle && typeof raw.detalle === 'object') ? (raw.detalle as Record<string, unknown>) : null,
     createdAt: raw.createdAt ? ensureIsoDate(raw.createdAt) : undefined,
     createdBy: ensureString(raw.createdBy ?? raw.usuarioAlta),


### PR DESCRIPTION
## Summary
- ensure gasto records prioritise tablaOrigen when deriving the displayed concepto value
- capture tablaOrigen driven concepto mapping in transformer unit tests

## Testing
- npm test *(fails: missing dependencies because npm install is blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68edb57094088330bf2360537d9603aa