### PR TITLE
feat(reportes): refresh consolidated report tables

### DIFF
--- a/frontend-app/src/modules/reportes/components/ReportTable.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportTable.tsx
@@ -9,71 +9,117 @@ function isNumericColumn(value: unknown): value is number {
   return typeof value === 'number' || (typeof value === 'string' && /^-?\d+[\d,.]*$/.test(value));
 }
 
+function formatCellValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  return String(value);
+}
+
 const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: ReportTableProps<Row>) => {
-  if (!descriptor.rows || descriptor.rows.length === 0) {
+  const hasRows = descriptor.rows && descriptor.rows.length > 0;
+  const titleId = `${descriptor.id}-title`;
+  const descriptionId = descriptor.description ? `${descriptor.id}-description` : undefined;
+
+  if (!hasRows) {
     return (
-      <div className="reportes-empty-state" role="status" aria-live="polite">
-        <h4>Sin datos</h4>
-        <p>{descriptor.emptyMessage ?? 'No se encontraron resultados para los filtros seleccionados.'}</p>
-      </div>
+      <section
+        className="reportes-table-card reportes-table-card--empty"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+      >
+        <header className="reportes-table-card__header">
+          <h4 id={titleId}>{descriptor.title}</h4>
+          {descriptor.description && <p id={descriptionId}>{descriptor.description}</p>}
+        </header>
+        <div className="reportes-table-card__body">
+          <div className="reportes-empty-state" role="status" aria-live="polite">
+            <h4>Sin datos</h4>
+            <p>{descriptor.emptyMessage ?? 'No se encontraron resultados para los filtros seleccionados.'}</p>
+          </div>
+        </div>
+      </section>
     );
   }
 
   return (
-    <div className="reportes-table-wrapper">
-      <table className="reportes-table" role="grid" aria-label={descriptor.title}>
-        <caption className="sr-only">{descriptor.description}</caption>
-        <thead>
-          <tr>
-            {descriptor.columns.map((column) => (
-              <th
-                key={String(column.id)}
-                scope="col"
-                className={column.isNumeric ? 'reportes-table__numeric' : undefined}
-              >
-                {column.label}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {descriptor.rows.map((row, index) => (
-            <tr key={index}>
-              {descriptor.columns.map((column) => {
-                const value = row[column.id];
-                const isNumeric = column.isNumeric ?? isNumericColumn(value);
-                return (
-                  <td
-                    key={String(column.id)}
-                    className={isNumeric ? 'reportes-table__numeric' : undefined}
-                    data-column={column.label}
-                  >
-                    {value === undefined || value === null || value === '' ? '—' : String(value)}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-        {descriptor.totalRow && (
-          <tfoot>
-            <tr>
-              {descriptor.columns.map((column, columnIndex) => {
-                const value = descriptor.totalRow?.[column.id];
-                return (
-                  <td
-                    key={String(column.id)}
-                    className={column.isNumeric ? 'reportes-table__numeric' : undefined}
-                  >
-                    {columnIndex === 0 && descriptor.totalRow?.label ? descriptor.totalRow.label : value ?? '—'}
-                  </td>
-                );
-              })}
-            </tr>
-          </tfoot>
-        )}
-      </table>
-    </div>
+    <section className="reportes-table-card" aria-labelledby={titleId} aria-describedby={descriptionId}>
+      <header className="reportes-table-card__header">
+        <h4 id={titleId}>{descriptor.title}</h4>
+        {descriptor.description && <p id={descriptionId}>{descriptor.description}</p>}
+      </header>
+      <div className="reportes-table-card__body">
+        <div className="reportes-table-wrapper">
+          <table
+            className="reportes-table"
+            role="grid"
+            aria-label={descriptor.title}
+            aria-describedby={descriptionId}
+          >
+            {descriptor.description && <caption className="sr-only">{descriptor.description}</caption>}
+            <thead>
+              <tr>
+                {descriptor.columns.map((column) => {
+                  const align = column.align ?? (column.isNumeric ? 'right' : 'left');
+                  return (
+                    <th key={String(column.id)} scope="col" style={{ textAlign: align }}>
+                      {column.label}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {descriptor.rows.map((row, index) => (
+                <tr key={index}>
+                  {descriptor.columns.map((column) => {
+                    const value = row[column.id];
+                    const isNumeric = column.isNumeric ?? isNumericColumn(value);
+                    const align = column.align ?? (isNumeric ? 'right' : 'left');
+
+                    return (
+                      <td
+                        key={String(column.id)}
+                        className="reportes-table__cell"
+                        data-column={column.label}
+                        style={{ textAlign: align }}
+                      >
+                        {formatCellValue(value)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+            {descriptor.totalRow && (
+              <tfoot>
+                <tr>
+                  {descriptor.columns.map((column, columnIndex) => {
+                    const value = descriptor.totalRow?.[column.id];
+                    const align = column.align ?? (column.isNumeric ? 'right' : 'left');
+                    const displayValue =
+                      columnIndex === 0 && descriptor.totalRow?.label
+                        ? descriptor.totalRow.label
+                        : formatCellValue(value);
+
+                    return (
+                      <td
+                        key={String(column.id)}
+                        className="reportes-table__cell"
+                        style={{ textAlign: align }}
+                      >
+                        {displayValue}
+                      </td>
+                    );
+                  })}
+                </tr>
+              </tfoot>
+            )}
+          </table>
+        </div>
+      </div>
+    </section>
   );
 };
 

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -211,38 +211,101 @@
   color: rgba(248, 250, 252, 0.9);
 }
 
+.reportes-table-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-outline);
+  border-radius: 16px;
+  box-shadow: var(--shadow-level-1);
+}
+
+.reportes-table-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-bottom: 1px solid var(--color-outline);
+  padding-bottom: 0.75rem;
+}
+
+.reportes-table-card__header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text-primary);
+}
+
+.reportes-table-card__header p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.reportes-table-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .reportes-table-wrapper {
-  overflow-x: auto;
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  overflow: auto;
 }
 
 .reportes-table {
   width: 100%;
+  min-width: 640px;
   border-collapse: collapse;
   font-size: 0.95rem;
 }
 
-.reportes-table thead {
-  background: #f1f5f9;
-  text-align: left;
+.reportes-table thead th {
+  background: rgba(20, 94, 168, 0.08);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-outline);
 }
 
-.reportes-table th,
-.reportes-table td {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid #e2e8f0;
+.reportes-table tbody tr {
+  transition: background-color 0.2s ease;
 }
 
-.reportes-table tbody tr:last-of-type td {
+.reportes-table tbody tr:hover {
+  background: rgba(20, 94, 168, 0.06);
+}
+
+.reportes-table__cell {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-outline);
+  color: var(--color-text-primary);
+  vertical-align: middle;
+}
+
+.reportes-table tbody tr:last-of-type .reportes-table__cell {
   border-bottom: none;
 }
 
-.reportes-table tfoot td {
-  background: #e2e8f0;
+.reportes-table tfoot .reportes-table__cell {
+  background: var(--color-primary-container);
+  color: var(--color-on-primary-container);
   font-weight: 600;
+  border-top: 1px solid var(--color-outline);
 }
 
-.reportes-table__numeric {
-  text-align: right;
+.reportes-table-card--empty .reportes-table-card__body {
+  align-items: stretch;
+}
+
+.reportes-table-card--empty .reportes-empty-state {
+  border: 1px dashed var(--color-outline);
+  background: rgba(241, 245, 249, 0.6);
 }
 
 .reportes-empty-state {


### PR DESCRIPTION
## Summary
- restyle consolidated report tables with card containers that match the operational datagrid look
- keep empty states and descriptions within the new layout for consistency
- align column headers with the cell content to improve readability

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68edb61fbc8c8330887dcaa4ab4b8f93