### PR TITLE
Mostrar origen de gasto en gastos consolidados

### DIFF
--- a/frontend-app/src/modules/configuracion/hooks/useCentrosApoyo.ts
+++ b/frontend-app/src/modules/configuracion/hooks/useCentrosApoyo.ts
@@ -51,7 +51,10 @@ function mapCentroApoyo(raw: any): CentroApoyo {
 }
 
 function mapExpense(raw: any): CentroApoyoExpense {
-  const id = raw?._id ?? raw?.id ?? `${raw?.concepto ?? 'gasto'}-${raw?.fechaCalculo ?? raw?.fecha ?? Date.now()}`;
+  const id =
+    raw?._id ??
+    raw?.id ??
+    `${raw?.tablaOrigen ?? raw?.concepto ?? 'gasto'}-${raw?.fechaCalculo ?? raw?.fecha ?? Date.now()}`;
   const rawMonto = raw?.monto ?? raw?.amount ?? raw?.total ?? 0;
   const categoria = raw?.categoria ?? raw?.tipo ?? raw?.conceptoTipo ?? 'Sin categoría';
   const rawPeriodo = raw?.esGastoDelPeriodo ?? raw?.delPeriodo ?? raw?.periodoActual;
@@ -64,7 +67,12 @@ function mapExpense(raw: any): CentroApoyoExpense {
 
   return {
     id: String(id),
-    concepto: typeof raw?.concepto === 'string' ? raw.concepto : raw?.descripcion ?? 'Sin concepto',
+    concepto:
+      typeof raw?.tablaOrigen === 'string'
+        ? raw.tablaOrigen
+        : typeof raw?.concepto === 'string'
+          ? raw.concepto
+          : raw?.descripcion ?? 'Sin concepto',
     categoria: String(categoria || 'Sin categoría'),
     monto: Number.isFinite(rawMonto) ? Number(rawMonto) : 0,
     esGastoDelPeriodo: Boolean(esDelPeriodo),

--- a/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
@@ -84,10 +84,9 @@ function exportToCsv(records: CentroApoyoExpense[], centro?: CentroApoyo) {
   if (records.length === 0) {
     return;
   }
-  const header = ['Concepto', 'Categoría', 'Monto', 'Del periodo', 'Fecha cálculo'];
+  const header = ['Concepto', 'Monto', 'Del periodo', 'Fecha cálculo'];
   const rows = records.map((record) => [
     record.concepto,
-    record.categoria,
     record.monto.toString(),
     record.esGastoDelPeriodo ? 'Sí' : 'No',
     record.fechaCalculo ?? '',
@@ -499,7 +498,6 @@ const CentrosApoyoPage: React.FC = () => {
                   <thead>
                     <tr>
                       <th>Concepto</th>
-                      <th>Categoría</th>
                       <th>Monto</th>
                       <th>Del periodo</th>
                       <th>Fecha cálculo</th>
@@ -509,7 +507,6 @@ const CentrosApoyoPage: React.FC = () => {
                     {gastos.map((gasto) => (
                       <tr key={gasto.id}>
                         <td>{gasto.concepto}</td>
-                        <td>{gasto.categoria}</td>
                         <td className="centros-apoyo__cell-right">
                           {formatCurrency(gasto.monto, { currency: gastosCurrency })}
                         </td>


### PR DESCRIPTION
## Summary
- mapear el valor de `tablaOrigen` como concepto principal de cada gasto consolidado
- actualizar la tabla y la exportación CSV para mostrar solo el concepto, monto, periodo y fecha de cálculo

## Testing
- npm run lint *(falla: falta la dependencia `@eslint/js` en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68edb6cc9a7c8330b1fe1198a0f23ffd