### PR TITLE
Remove tipo column from gastos table

### DIFF
--- a/frontend-app/src/modules/costos/pages/config.ts
+++ b/frontend-app/src/modules/costos/pages/config.ts
@@ -35,7 +35,6 @@ export const costosConfigs: Record<Exclude<CostosSubModulo, 'prorrateo'>, Costos
       { key: 'fecha', label: 'Fecha', width: '120px' },
       { key: 'centro', label: 'Centro', width: '100px' },
       { key: 'concepto', label: 'Concepto', width: '220px' },
-      { key: 'tipo', label: 'Tipo', width: '160px' },
       { key: 'monto', label: 'Monto', width: '140px', align: 'right' },
       { key: 'esGastoDelPeriodo', label: 'Del periodo', width: '120px', align: 'center' },
     ],


### PR DESCRIPTION
## Summary
- remove the Tipo column from the gastos table configuration so it no longer renders

## Testing
- npm run lint *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68edb84bfb188330b9b78b0750dae764