### PR TITLE
Group expense chart by concept

### DIFF
--- a/frontend-app/src/modules/configuracion/__tests__/centrosApoyo.test.js
+++ b/frontend-app/src/modules/configuracion/__tests__/centrosApoyo.test.js
@@ -28,17 +28,19 @@ const sampleExpenses = [
 ];
 
 describe('buildCentrosApoyoSummary', () => {
-  it('calcula totales y porcentajes por categoría', () => {
+  it('calcula totales y porcentajes por concepto', () => {
     const summary = buildCentrosApoyoSummary(sampleExpenses);
     expect(summary.total).toBeCloseTo(28650.45, 2);
     expect(summary.periodTotal).toBeCloseTo(24450.45, 2);
     expect(summary.outOfPeriodTotal).toBeCloseTo(4200, 2);
-    expect(summary.categories).toHaveLength(2);
+    expect(summary.categories).toHaveLength(3);
     expect(summary.categories[0].category).toBe('Energía');
-    expect(summary.categories[0].amount).toBeCloseTo(22450.45, 2);
-    expect(summary.categories[0].percentage).toBeCloseTo(22450.45 / 28650.45, 5);
+    expect(summary.categories[0].amount).toBeCloseTo(18250.45, 2);
+    expect(summary.categories[0].percentage).toBeCloseTo(18250.45 / 28650.45, 5);
     expect(summary.categories[1].category).toBe('Caldera');
     expect(summary.categories[1].amount).toBeCloseTo(6200, 2);
+    expect(summary.categories[2].category).toBe('Refrigeración');
+    expect(summary.categories[2].amount).toBeCloseTo(4200, 2);
   });
 
   it('devuelve ceros cuando no hay gastos', () => {

--- a/frontend-app/src/modules/configuracion/utils/centrosApoyo.ts
+++ b/frontend-app/src/modules/configuracion/utils/centrosApoyo.ts
@@ -17,7 +17,7 @@ export function buildCentrosApoyoSummary(expenses: CentroApoyoExpense[]): Centro
   let total = 0;
   let periodTotal = 0;
   let outOfPeriodTotal = 0;
-  const categoryTotals = new Map<string, number>();
+  const conceptTotals = new Map<string, number>();
 
   for (const expense of expenses) {
     const amount = Number.isFinite(expense.monto) ? expense.monto : 0;
@@ -27,11 +27,11 @@ export function buildCentrosApoyoSummary(expenses: CentroApoyoExpense[]): Centro
     } else {
       outOfPeriodTotal += amount;
     }
-    const key = expense.categoria || 'Sin categoría';
-    categoryTotals.set(key, (categoryTotals.get(key) ?? 0) + amount);
+    const key = expense.concepto || 'Sin concepto';
+    conceptTotals.set(key, (conceptTotals.get(key) ?? 0) + amount);
   }
 
-  const categories: CentroApoyoCategoryBreakdown[] = Array.from(categoryTotals.entries())
+  const categories: CentroApoyoCategoryBreakdown[] = Array.from(conceptTotals.entries())
     .map(([category, amount]) => ({
       category,
       amount,


### PR DESCRIPTION
## Summary
- aggregate centro de apoyo expenses by concepto/tablaOrigen when building the chart data
- update the unit test expectations to reflect the concept-based breakdown

## Testing
- `npm test -- --runTestsByPath src/modules/configuracion/__tests__/centrosApoyo.test.js` *(fails: TypeScript cannot find Node type definitions because npm install is blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68edb9b611588330990eaa91f283f076