### PR TITLE
feat: allow editing and deleting sueldos records

### DIFF
--- a/frontend-app/src/modules/costos/components/CostosDataTable.tsx
+++ b/frontend-app/src/modules/costos/components/CostosDataTable.tsx
@@ -24,6 +24,11 @@ interface CostosDataTableProps<K extends Exclude<CostosSubModulo, 'prorrateo'>> 
   onSelect: (record: CostosRecordMap[K] | null) => void;
   selectedId: string | null;
   onAction?: (actionId: string) => void;
+  rowActions?: {
+    header: string;
+    width?: string;
+    render: (record: CostosRecordMap[K]) => React.ReactNode;
+  };
 }
 
 function formatDate(value: string | undefined | null): string {
@@ -96,6 +101,7 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
   onSelect,
   selectedId,
   onAction,
+  rowActions,
 }: CostosDataTableProps<K>) => {
   const pagination = usePagination(records, {
     initialPageSize: 25,
@@ -188,6 +194,11 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
                     {column.label}
                   </th>
                 ))}
+                {rowActions && (
+                  <th scope="col" style={{ width: rowActions.width }}>
+                    {rowActions.header}
+                  </th>
+                )}
                 <th scope="col">Trazabilidad</th>
               </tr>
             </thead>
@@ -209,6 +220,14 @@ const CostosDataTable = <K extends Exclude<CostosSubModulo, 'prorrateo'>>({
                         {getCellValue(record, column, currency)}
                       </td>
                     ))}
+                    {rowActions && (
+                      <td
+                        className="operacion-datagrid__cell operacion-datagrid__cell--nowrap costos-datagrid__actions-cell"
+                        style={{ width: rowActions.width }}
+                      >
+                        {rowActions.render(record)}
+                      </td>
+                    )}
                     <td className="operacion-datagrid__cell operacion-datagrid__cell--nowrap">
                       <span className="costos-datagrid__trace operacion-chip sync">{buildTraceLabel(record)}</span>
                     </td>

--- a/frontend-app/src/modules/costos/costos.css
+++ b/frontend-app/src/modules/costos/costos.css
@@ -276,6 +276,63 @@
   min-width: 140px;
 }
 
+.costos-datagrid__actions-cell {
+  text-align: left;
+}
+
+.costos-row-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.costos-row-actions__edit,
+.costos-row-actions__delete {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.costos-row-actions__edit {
+  background: rgba(20, 94, 168, 0.12);
+  color: var(--color-primary-variant);
+}
+
+.costos-row-actions__edit:hover,
+.costos-row-actions__edit:focus-visible {
+  background: rgba(20, 94, 168, 0.18);
+  box-shadow: 0 0 0 3px rgba(20, 94, 168, 0.16);
+}
+
+.costos-row-actions__delete {
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+}
+
+.costos-row-actions__delete:hover,
+.costos-row-actions__delete:focus-visible {
+  background: rgba(248, 113, 113, 0.2);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.18);
+}
+
+.costos-row-actions__delete:focus-visible,
+.costos-row-actions__edit:focus-visible {
+  outline: none;
+}
+
+.costos-row-actions__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .costos-datagrid__trace {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- capture the esGastoDelPeriodo flag when creating or editing sueldos
- add inline edit/delete actions for sueldos rows with confirmation and API calls
- style the new action buttons to match the grid UI

## Testing
- npm run lint *(fails: missing dependencies because registry access to `@eslint/js` is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edbb79a8708330ad8357d52b32b9f8