### PR TITLE
Update centros de apoyo editing workflow

### DIFF
--- a/frontend-app/src/modules/configuracion/configuracion.css
+++ b/frontend-app/src/modules/configuracion/configuracion.css
@@ -619,19 +619,6 @@ textarea.config-input {
   gap: 24px;
 }
 
-.centros-apoyo__layout {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-  align-items: start;
-}
-
-@media (max-width: 1100px) {
-  .centros-apoyo__layout {
-    grid-template-columns: 1fr;
-  }
-}
-
 .centros-apoyo__gastos,
 .centros-apoyo__edicion {
   display: flex;


### PR DESCRIPTION
## Summary
- show the centros de apoyo edit form in place of the catalog grid when editing and reuse the existing actions
- trigger gastos retrieval when selecting a centro and keep the editing reset behaviour
- simplify layout styles now that the secondary edit card is no longer rendered

## Testing
- npm ci *(fails: 403 Forbidden fetching recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68edbcaf15308330af05f9fe5376ad7f