### PR TITLE
Fix prorrateo filters to display existing cost data

### DIFF
--- a/frontend-app/src/modules/costos/hooks/useCostosData.ts
+++ b/frontend-app/src/modules/costos/hooks/useCostosData.ts
@@ -43,10 +43,19 @@ interface UseCostosDataResult<K extends Exclude<CostosSubModulo, 'prorrateo'>> {
 export function useCostosData<K extends Exclude<CostosSubModulo, 'prorrateo'>>(): UseCostosDataResult<K> {
   const { submodule, filters, setLastSummary } = useCostosContext();
   const effectiveSubmodule = (submodule === 'prorrateo' ? 'gastos' : submodule) as K;
+  const effectiveFilters = useMemo(() => {
+    if (submodule === 'prorrateo') {
+      return {
+        ...filters,
+        esGastoDelPeriodo: filters.esGastoDelPeriodo ?? true,
+      };
+    }
+    return filters;
+  }, [filters, submodule]);
 
   const query = useQuery<CostosListResponse<CostosRecordMap[K]>>({
-    queryKey: ['costos', effectiveSubmodule, filters],
-    queryFn: () => fetchCostosList(effectiveSubmodule, filters),
+    queryKey: ['costos', effectiveSubmodule, effectiveFilters],
+    queryFn: () => fetchCostosList(effectiveSubmodule, effectiveFilters),
   });
 
   const summary = useMemo(() => calculateBalanceSummary(query.data), [query.data]);


### PR DESCRIPTION
## Summary
- share filter defaults between prorrateo and gastos so the consolidation view keeps the required period flag
- adjust the costos data hook to enforce the esGastoDelPeriodo filter when reading prorrateo data

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68edbeb851c483308220bc15dcb44b45