### PR TITLE
Remove disabled topbar buttons

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -418,61 +418,6 @@ button.small {
   outline-offset: 2px;
 }
 
-.app-navbar__actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.app-navbar__action {
-  border: 1px solid rgba(226, 232, 240, 0.25);
-  border-radius: 12px;
-  padding: 10px 18px;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  color: var(--color-navbar-text);
-  background: rgba(15, 23, 42, 0.35);
-  backdrop-filter: blur(8px);
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.app-navbar__action:hover {
-  background: rgba(99, 102, 241, 0.18);
-  border-color: rgba(96, 165, 250, 0.6);
-  color: var(--color-navbar-accent);
-  transform: translateY(-1px);
-}
-
-.app-navbar__action[disabled],
-.app-navbar__action[disabled]:hover {
-  cursor: not-allowed;
-  background: rgba(15, 23, 42, 0.18);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: rgba(226, 232, 240, 0.75);
-  transform: none;
-}
-
-.app-navbar__action--primary {
-  background: rgba(59, 130, 246, 0.85);
-  border-color: rgba(96, 165, 250, 0.9);
-  color: #f8fafc;
-}
-
-.app-navbar__action--primary:hover {
-  background: rgba(37, 99, 235, 0.92);
-  border-color: rgba(59, 130, 246, 0.95);
-  color: #f8fafc;
-}
-
-.app-navbar__action--primary[disabled],
-.app-navbar__action--primary[disabled]:hover {
-  background: rgba(59, 130, 246, 0.5);
-  border-color: rgba(96, 165, 250, 0.45);
-  color: rgba(248, 250, 252, 0.8);
-}
-
 .app-shell__content {
   flex: 1;
   width: 100%;
@@ -837,15 +782,6 @@ button.small {
     width: 100%;
   }
 
-  .app-navbar__actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .app-navbar__action {
-    flex: 1 1 auto;
-    text-align: center;
-  }
 }
 
 @media (max-width: 640px) {

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -21,13 +21,6 @@ type NavItem = {
 };
 type DomainKey = 'configuracion' | 'operacion' | 'importaciones' | 'costos' | 'reportes';
 
-type DomainAction = {
-  label: string;
-  variant?: 'primary' | 'default';
-  disabled?: boolean;
-  description?: string;
-};
-
 type SidebarStat = {
   value: string;
   label: string;
@@ -38,7 +31,6 @@ type DomainConfig = {
   title: string;
   subtitle: string;
   logo: string;
-  actions: DomainAction[];
   overview: {
     description: string;
     stats: SidebarStat[];
@@ -164,19 +156,6 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     title: 'Configuración y catálogos',
     subtitle: 'Administra los catálogos maestros y parámetros generales utilizados por los módulos operativos.',
     logo: '🌿',
-    actions: [
-      {
-        label: 'Agregar catálogo',
-        variant: 'primary',
-        disabled: true,
-        description: 'Disponible cuando se integre el flujo de alta de catálogos con el backend.',
-      },
-      {
-        label: 'Centro de ayuda',
-        disabled: true,
-        description: 'Enlace en preparación; se habilitará al publicar la documentación oficial.',
-      },
-    ],
     overview: {
       description:
         'Consulta el estado general de los catálogos y mantén visibles las dependencias clave antes de publicar cambios.',
@@ -194,19 +173,6 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     subtitle:
       'Captura y monitorea consumos, producciones, litros, pérdidas y sobrantes con trazabilidad y cierres controlados.',
     logo: '🛠️',
-    actions: [
-      {
-        label: 'Nueva importación',
-        variant: 'primary',
-        disabled: true,
-        description: 'Acceso directo pendiente; utiliza el módulo de Importaciones para realizar cargas.',
-      },
-      {
-        label: 'Ver bitácoras',
-        disabled: true,
-        description: 'Se habilitará cuando se publique el listado resumido de bitácoras.',
-      },
-    ],
     overview: {
       description:
         'Supervisa la captura diaria, valida cierres pendientes y sincroniza los módulos dependientes en tiempo real.',
@@ -224,19 +190,6 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     subtitle:
       'Controla gastos, depreciaciones, sueldos y monitorea las consolidaciones automáticas con trazabilidad completa.',
     logo: '💰',
-    actions: [
-      {
-        label: 'Reprocesar consolidación',
-        variant: 'primary',
-        disabled: true,
-        description: 'La consolidación se ejecuta automáticamente; esta acción se reservará para el backend real.',
-      },
-      {
-        label: 'Historial de bitácoras',
-        disabled: true,
-        description: 'Acceso directo pendiente; consulta el módulo de Costos para los detalles.',
-      },
-    ],
     overview: {
       description:
         'Consulta balances, identifica variaciones entre periodos y navega rápidamente hacia existencias y asientos relacionados.',
@@ -254,19 +207,6 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     subtitle:
       'Explora indicadores financieros, operativos y de auditoría con filtros avanzados y exportaciones seguras.',
     logo: '📊',
-    actions: [
-      {
-        label: 'Descargar guía rápida',
-        disabled: true,
-        description: 'La guía estará disponible cuando se publique la documentación de reportes.',
-      },
-      {
-        label: 'Solicitar nuevo reporte',
-        variant: 'primary',
-        disabled: true,
-        description: 'Funcionalidad pendiente de integrar con el flujo de solicitudes.',
-      },
-    ],
     overview: {
       description:
         'Comparte vistas filtradas, monitorea descargas recientes y asegura el cumplimiento de los indicadores clave.',
@@ -284,19 +224,6 @@ const domainConfigs: Record<DomainKey, DomainConfig> = {
     subtitle:
       'Carga archivos .mdb, monitorea el procesamiento por tabla y gestiona las bitácoras generadas automáticamente.',
     logo: '📥',
-    actions: [
-      {
-        label: 'Nueva importación',
-        variant: 'primary',
-        disabled: true,
-        description: 'Utiliza la pestaña Importar archivo para ejecutar cargas mientras se habilita este acceso rápido.',
-      },
-      {
-        label: 'Bitácoras recientes',
-        disabled: true,
-        description: 'Se activará cuando se exponga el resumen de bitácoras.',
-      },
-    ],
     overview: {
       description:
         'Controla la trazabilidad de las importaciones, revisa los resultados por tabla y audita los movimientos generados.',
@@ -702,20 +629,6 @@ function App() {
                 </div>
               </div>
             </div>
-          </div>
-          <div className="app-navbar__actions" aria-label="Acciones rápidas">
-            {domainConfig.actions.map((action) => (
-              <button
-                key={action.label}
-                type="button"
-                className={`app-navbar__action${action.variant === 'primary' ? ' app-navbar__action--primary' : ''}`}
-                disabled={action.disabled ?? false}
-                aria-disabled={action.disabled ? 'true' : undefined}
-                title={action.disabled ? action.description ?? 'Acción disponible próximamente.' : undefined}
-              >
-                {action.label}
-              </button>
-            ))}
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- remove the unused domain action metadata now that the topbar quick actions are gone
- delete the header action buttons from the navbar so only the brand and domain selector remain
- clean up the stylesheet by dropping styles tied to the removed buttons

## Testing
- npm run build *(fails: missing `vite/client` and `node` type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68edca69486c8330b6ebe5d8cb5a3ad3