### PR TITLE
Integrate cuadros report into financial dashboard

### DIFF
--- a/frontend-app/src/modules/reportes/__tests__/normalizers.test.ts
+++ b/frontend-app/src/modules/reportes/__tests__/normalizers.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeCuadrosResponse } from '../utils/normalizers.js';
+
+test('normalizeCuadrosResponse formatea montos y clasifica tonos', () => {
+  const response = [
+    { id: 'card-1', producto: 'Queso manchego', periodo: '2024-05-01', costoDirecto: 1000, costoIndirecto: 1020 },
+    { id: 'card-2', producto: 'Crema doble', periodo: '2024-05-01', costoDirecto: 1250, costoIndirecto: 800 },
+  ];
+
+  const cards = normalizeCuadrosResponse(response);
+
+  assert.equal(cards.length, 2);
+  const first = cards[0];
+  assert.equal(first.producto, 'Queso manchego');
+  assert.equal(first.periodoLabel, '2024-05');
+  assert.equal(first.costoDirecto.includes('$'), true);
+  assert.equal(first.costoIndirecto.includes('$'), true);
+  assert.equal(first.diferencia.includes('$'), true);
+  assert.equal(first.tone, 'success');
+  assert.ok(first.diferenciaPorcentaje?.includes('%'));
+
+  const second = cards[1];
+  assert.equal(second.tone, 'danger');
+  assert.equal(second.diferencia.startsWith('-'), true);
+});

--- a/frontend-app/src/modules/reportes/api/reportesApi.ts
+++ b/frontend-app/src/modules/reportes/api/reportesApi.ts
@@ -7,12 +7,14 @@ import type {
   ReportFilters,
   ReportFormat,
   ReportId,
+  ReportCuadroCard,
   ReportSummaryCard,
   ReportTableDescriptor,
 } from '../types';
 import {
   buildComparisonInsight,
   buildCostosSummaryCards,
+  normalizeCuadrosResponse,
   normalizeAsignacionesResponse,
   normalizeComparativoResponse,
   normalizeConsumosResponse,
@@ -30,6 +32,7 @@ const endpointMap: Record<ReportId, string> = {
   consumos: '/api/reportes/consumos',
   asignaciones: '/api/reportes/asignaciones',
   'mano-obra': '/api/reportes/mano-obra',
+  cuadros: '/api/reportes/cuadros',
   descargas: '/api/reportes/descargas',
 };
 
@@ -93,6 +96,12 @@ export async function fetchComparativoReport(
     points: normalizeComparativoResponse(response),
     insight: buildComparisonInsight(response),
   };
+}
+
+export async function fetchCuadrosReport(filters: ReportFilters): Promise<ReportCuadroCard[]> {
+  const query = serializeFiltersToSearch(filters);
+  const response = await apiClient.get<unknown>(buildUrl('cuadros', query));
+  return normalizeCuadrosResponse(response);
 }
 
 export async function fetchConsumosReport(filters: ReportFilters): Promise<ReportTableDescriptor> {

--- a/frontend-app/src/modules/reportes/components/CuadrosComparativos.tsx
+++ b/frontend-app/src/modules/reportes/components/CuadrosComparativos.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import type { ReportCuadroCard } from '../types';
+
+interface CuadrosComparativosProps {
+  cards: ReportCuadroCard[];
+}
+
+const toneClassMap: Record<ReportCuadroCard['tone'], string> = {
+  default: '',
+  success: 'reportes-cuadro-card--success',
+  warning: 'reportes-cuadro-card--warning',
+  danger: 'reportes-cuadro-card--danger',
+};
+
+const CuadrosComparativos: React.FC<CuadrosComparativosProps> = ({ cards }) => (
+  <section aria-label="Cuadros comparativos de costos" className="reportes-cuadros-grid">
+    {cards.map((card) => (
+      <article key={card.id} className={`reportes-cuadro-card ${toneClassMap[card.tone]}`}>
+        <header className="reportes-cuadro-card__header">
+          <h4>{card.producto}</h4>
+          {card.periodoLabel && <span>{card.periodoLabel}</span>}
+        </header>
+        <dl className="reportes-cuadro-card__metrics">
+          <div>
+            <dt>Costo directo</dt>
+            <dd>{card.costoDirecto}</dd>
+          </div>
+          <div>
+            <dt>Costo indirecto</dt>
+            <dd>{card.costoIndirecto}</dd>
+          </div>
+        </dl>
+        <footer className="reportes-cuadro-card__footer">
+          <div className="reportes-cuadro-card__difference">
+            <strong>{card.diferencia}</strong>
+            {card.diferenciaPorcentaje && <span>{card.diferenciaPorcentaje}</span>}
+          </div>
+          {card.tendenciaLabel && <p>{card.tendenciaLabel}</p>}
+        </footer>
+      </article>
+    ))}
+  </section>
+);
+
+export default CuadrosComparativos;

--- a/frontend-app/src/modules/reportes/pages/FinancierosPage.tsx
+++ b/frontend-app/src/modules/reportes/pages/FinancierosPage.tsx
@@ -5,12 +5,14 @@ import ReportTable from '../components/ReportTable';
 import ExportToolbar from '../components/ExportToolbar';
 import ReportSkeleton from '../components/ReportSkeleton';
 import ComparisonChart from '../components/ComparisonChart';
+import CuadrosComparativos from '../components/CuadrosComparativos';
 import { useReportQuery } from '../hooks/useReportQuery';
-import { fetchComparativoReport, fetchCostosReport } from '../api/reportesApi';
+import { fetchComparativoReport, fetchCostosReport, fetchCuadrosReport } from '../api/reportesApi';
 
 const FinancierosPage: React.FC = () => {
   const costosQuery = useReportQuery({ reportId: 'costos', fetcher: fetchCostosReport });
   const comparativoQuery = useReportQuery({ reportId: 'comparativo', fetcher: fetchComparativoReport });
+  const cuadrosQuery = useReportQuery({ reportId: 'cuadros', fetcher: fetchCuadrosReport });
 
   const isLoading = costosQuery.status === 'loading';
   const hasError = costosQuery.status === 'error';
@@ -36,6 +38,27 @@ const FinancierosPage: React.FC = () => {
               <ReportTable key={table.id} descriptor={table} />
             ))}
           </>
+        )}
+      </ReportSection>
+
+      <ReportSection
+        title="Cuadros comparativos"
+        description="Contrasta costos directos e indirectos por producto para identificar desviaciones."
+        actions={<ExportToolbar reportId="cuadros" disabled={cuadrosQuery.status === 'error'} />}
+      >
+        {cuadrosQuery.status === 'loading' && <ReportSkeleton />}
+        {cuadrosQuery.status === 'error' && (
+          <div role="alert" className="reportes-empty-state">
+            <h4>No fue posible recuperar los cuadros comparativos</h4>
+            <p>Vuelve a intentarlo más tarde o ajusta los filtros de consulta.</p>
+          </div>
+        )}
+        {cuadrosQuery.data && cuadrosQuery.data.length > 0 && <CuadrosComparativos cards={cuadrosQuery.data} />}
+        {cuadrosQuery.data && cuadrosQuery.data.length === 0 && cuadrosQuery.status !== 'error' && (
+          <div role="status" className="reportes-empty-state">
+            <h4>Sin datos disponibles</h4>
+            <p>No se encontraron registros de costos directos o indirectos con los filtros actuales.</p>
+          </div>
         )}
       </ReportSection>
 

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -211,6 +211,103 @@
   color: rgba(248, 250, 252, 0.9);
 }
 
+.reportes-cuadros-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.reportes-cuadro-card {
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-outline);
+  box-shadow: var(--shadow-level-1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.reportes-cuadro-card--success {
+  border-color: rgba(13, 148, 136, 0.35);
+  box-shadow: 0 12px 28px rgba(13, 148, 136, 0.15);
+}
+
+.reportes-cuadro-card--warning {
+  border-color: rgba(234, 179, 8, 0.35);
+  box-shadow: 0 12px 28px rgba(234, 179, 8, 0.18);
+}
+
+.reportes-cuadro-card--danger {
+  border-color: rgba(249, 115, 22, 0.35);
+  box-shadow: 0 12px 32px rgba(249, 115, 22, 0.22);
+}
+
+.reportes-cuadro-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.reportes-cuadro-card__header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text-primary);
+}
+
+.reportes-cuadro-card__header span {
+  color: var(--color-text-tertiary);
+  font-size: 0.85rem;
+}
+
+.reportes-cuadro-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.reportes-cuadro-card__metrics dt {
+  margin: 0;
+  color: var(--color-text-tertiary);
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.reportes-cuadro-card__metrics dd {
+  margin: 0.15rem 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.reportes-cuadro-card__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.reportes-cuadro-card__difference {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.reportes-cuadro-card__difference strong {
+  font-size: 1.1rem;
+  color: var(--color-text-primary);
+}
+
+.reportes-cuadro-card__difference span {
+  font-size: 0.85rem;
+  color: var(--color-text-tertiary);
+}
+
 .reportes-table-card {
   display: flex;
   flex-direction: column;

--- a/frontend-app/src/modules/reportes/types.ts
+++ b/frontend-app/src/modules/reportes/types.ts
@@ -16,6 +16,7 @@ export type ReportId =
   | 'consumos'
   | 'asignaciones'
   | 'mano-obra'
+  | 'cuadros'
   | 'descargas';
 
 export interface ReportRoute {
@@ -71,6 +72,18 @@ export interface ReportSummaryCard {
   value: string;
   helpText?: string;
   tone?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+export interface ReportCuadroCard {
+  id: string;
+  producto: string;
+  periodoLabel?: string;
+  costoDirecto: string;
+  costoIndirecto: string;
+  diferencia: string;
+  diferenciaPorcentaje?: string;
+  tone: 'default' | 'success' | 'warning' | 'danger';
+  tendenciaLabel?: string;
 }
 
 export interface ComparisonPoint {


### PR DESCRIPTION
## Summary
- add a CuadrosComparativos component and render the /api/reportes/cuadros cards within the financieros view
- extend report types, normalizers, and API helpers so the cuadros endpoint can be exported alongside the other reports
- add coverage for the cuadros normalizer with a node:test case

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68efa87525b08330b426b8ca29798da6