### PR TITLE
Transform comparative cards into table layout

### DIFF
--- a/frontend-app/src/modules/reportes/components/CuadrosComparativos.tsx
+++ b/frontend-app/src/modules/reportes/components/CuadrosComparativos.tsx
@@ -5,41 +5,115 @@ interface CuadrosComparativosProps {
   cards: ReportCuadroCard[];
 }
 
-const toneClassMap: Record<ReportCuadroCard['tone'], string> = {
+const toneRowClassMap: Record<ReportCuadroCard['tone'], string> = {
   default: '',
-  success: 'reportes-cuadro-card--success',
-  warning: 'reportes-cuadro-card--warning',
-  danger: 'reportes-cuadro-card--danger',
+  success: 'reportes-cuadros-row--success',
+  warning: 'reportes-cuadros-row--warning',
+  danger: 'reportes-cuadros-row--danger',
 };
 
-const CuadrosComparativos: React.FC<CuadrosComparativosProps> = ({ cards }) => (
-  <section aria-label="Cuadros comparativos de costos" className="reportes-cuadros-grid">
-    {cards.map((card) => (
-      <article key={card.id} className={`reportes-cuadro-card ${toneClassMap[card.tone]}`}>
-        <header className="reportes-cuadro-card__header">
-          <h4>{card.producto}</h4>
-          {card.periodoLabel && <span>{card.periodoLabel}</span>}
-        </header>
-        <dl className="reportes-cuadro-card__metrics">
-          <div>
-            <dt>Costo directo</dt>
-            <dd>{card.costoDirecto}</dd>
-          </div>
-          <div>
-            <dt>Costo indirecto</dt>
-            <dd>{card.costoIndirecto}</dd>
-          </div>
-        </dl>
-        <footer className="reportes-cuadro-card__footer">
-          <div className="reportes-cuadro-card__difference">
-            <strong>{card.diferencia}</strong>
-            {card.diferenciaPorcentaje && <span>{card.diferenciaPorcentaje}</span>}
-          </div>
-          {card.tendenciaLabel && <p>{card.tendenciaLabel}</p>}
-        </footer>
-      </article>
-    ))}
-  </section>
-);
+const CuadrosComparativos: React.FC<CuadrosComparativosProps> = ({ cards }) => {
+  const tableTitleId = 'cuadros-comparativos-table-title';
+  const descriptionId = 'cuadros-comparativos-table-description';
+  const hasPeriodoColumn = cards.some((card) => Boolean(card.periodoLabel));
+  const hasTendenciaColumn = cards.some((card) => Boolean(card.tendenciaLabel));
+
+  return (
+    <section
+      className="reportes-table-card"
+      aria-labelledby={tableTitleId}
+      aria-describedby={descriptionId}
+    >
+      <header className="reportes-table-card__header">
+        <h4 id={tableTitleId}>Detalle por producto</h4>
+        <p id={descriptionId}>Comparativo de costos directos e indirectos.</p>
+      </header>
+      <div className="reportes-table-card__body">
+        <div className="reportes-table-wrapper">
+          <table
+            className="reportes-table"
+            role="grid"
+            aria-label="Detalle de cuadros comparativos por producto"
+            aria-describedby={descriptionId}
+          >
+            <thead>
+              <tr>
+                <th scope="col" style={{ textAlign: 'left' }}>
+                  Producto
+                </th>
+                {hasPeriodoColumn && (
+                  <th scope="col" style={{ textAlign: 'left' }}>
+                    Periodo
+                  </th>
+                )}
+                <th scope="col" style={{ textAlign: 'right' }}>
+                  Costo directo
+                </th>
+                <th scope="col" style={{ textAlign: 'right' }}>
+                  Costo indirecto
+                </th>
+                <th scope="col" style={{ textAlign: 'right' }}>
+                  Diferencia
+                </th>
+                {hasTendenciaColumn && (
+                  <th scope="col" style={{ textAlign: 'left' }}>
+                    Tendencia
+                  </th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {cards.map((card) => (
+                <tr key={card.id} className={toneRowClassMap[card.tone]}>
+                  <th scope="row" className="reportes-table__cell reportes-table__cell--row-header">
+                    {card.producto}
+                  </th>
+                  {hasPeriodoColumn && (
+                    <td className="reportes-table__cell" data-column="Periodo">
+                      {card.periodoLabel ?? '—'}
+                    </td>
+                  )}
+                  <td
+                    className="reportes-table__cell"
+                    data-column="Costo directo"
+                    style={{ textAlign: 'right' }}
+                  >
+                    {card.costoDirecto}
+                  </td>
+                  <td
+                    className="reportes-table__cell"
+                    data-column="Costo indirecto"
+                    style={{ textAlign: 'right' }}
+                  >
+                    {card.costoIndirecto}
+                  </td>
+                  <td
+                    className="reportes-table__cell"
+                    data-column="Diferencia"
+                    style={{ textAlign: 'right' }}
+                  >
+                    <div className="reportes-cuadros-difference">
+                      <span className="reportes-cuadros-difference__value">{card.diferencia}</span>
+                      {card.diferenciaPorcentaje && (
+                        <span className="reportes-cuadros-difference__percentage">
+                          {card.diferenciaPorcentaje}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  {hasTendenciaColumn && (
+                    <td className="reportes-table__cell" data-column="Tendencia">
+                      {card.tendenciaLabel ?? '—'}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+};
 
 export default CuadrosComparativos;

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -211,101 +211,50 @@
   color: rgba(248, 250, 252, 0.9);
 }
 
-.reportes-cuadros-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
-
-.reportes-cuadro-card {
-  border-radius: 16px;
-  padding: 1.25rem;
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-outline);
-  box-shadow: var(--shadow-level-1);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  transition: transform 150ms ease, box-shadow 150ms ease;
-}
-
-.reportes-cuadro-card--success {
-  border-color: rgba(13, 148, 136, 0.35);
-  box-shadow: 0 12px 28px rgba(13, 148, 136, 0.15);
-}
-
-.reportes-cuadro-card--warning {
-  border-color: rgba(234, 179, 8, 0.35);
-  box-shadow: 0 12px 28px rgba(234, 179, 8, 0.18);
-}
-
-.reportes-cuadro-card--danger {
-  border-color: rgba(249, 115, 22, 0.35);
-  box-shadow: 0 12px 32px rgba(249, 115, 22, 0.22);
-}
-
-.reportes-cuadro-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 0.75rem;
-}
-
-.reportes-cuadro-card__header h4 {
-  margin: 0;
-  font-size: 1rem;
-  color: var(--color-text-primary);
-}
-
-.reportes-cuadro-card__header span {
-  color: var(--color-text-tertiary);
-  font-size: 0.85rem;
-}
-
-.reportes-cuadro-card__metrics {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.reportes-cuadro-card__metrics dt {
-  margin: 0;
-  color: var(--color-text-tertiary);
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.reportes-cuadro-card__metrics dd {
-  margin: 0.15rem 0 0;
-  font-size: 1.1rem;
+.reportes-table__cell--row-header {
   font-weight: 600;
-  color: var(--color-text-primary);
 }
 
-.reportes-cuadro-card__footer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  color: var(--color-text-secondary);
-  font-size: 0.9rem;
-}
-
-.reportes-cuadro-card__difference {
-  display: flex;
-  gap: 0.5rem;
+.reportes-cuadros-difference {
+  display: inline-flex;
   align-items: baseline;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  width: 100%;
 }
 
-.reportes-cuadro-card__difference strong {
-  font-size: 1.1rem;
+.reportes-cuadros-difference__value {
   color: var(--color-text-primary);
+  font-weight: 600;
 }
 
-.reportes-cuadro-card__difference span {
-  font-size: 0.85rem;
+.reportes-cuadros-difference__percentage {
   color: var(--color-text-tertiary);
+  font-size: 0.85rem;
+}
+
+.reportes-table tbody tr.reportes-cuadros-row--success .reportes-table__cell {
+  background: rgba(13, 148, 136, 0.08);
+}
+
+.reportes-table tbody tr.reportes-cuadros-row--warning .reportes-table__cell {
+  background: rgba(234, 179, 8, 0.1);
+}
+
+.reportes-table tbody tr.reportes-cuadros-row--danger .reportes-table__cell {
+  background: rgba(249, 115, 22, 0.1);
+}
+
+.reportes-table tbody tr.reportes-cuadros-row--success:hover .reportes-table__cell {
+  background: rgba(13, 148, 136, 0.14);
+}
+
+.reportes-table tbody tr.reportes-cuadros-row--warning:hover .reportes-table__cell {
+  background: rgba(234, 179, 8, 0.16);
+}
+
+.reportes-table tbody tr.reportes-cuadros-row--danger:hover .reportes-table__cell {
+  background: rgba(249, 115, 22, 0.18);
 }
 
 .reportes-table-card {


### PR DESCRIPTION
## Summary
- replace the comparative cost cards with a tabular layout consistent with other report sections
- add styling hooks to highlight table rows by tone and preserve difference formatting

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efadc7f7b48330b4aa852dc5a20313