### PR TITLE
Align product detail report table with catalog interactions

### DIFF
--- a/frontend-app/src/modules/reportes/components/CuadrosComparativos.tsx
+++ b/frontend-app/src/modules/reportes/components/CuadrosComparativos.tsx
@@ -12,15 +12,90 @@ const toneRowClassMap: Record<ReportCuadroCard['tone'], string> = {
   danger: 'reportes-cuadros-row--danger',
 };
 
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
+
 const CuadrosComparativos: React.FC<CuadrosComparativosProps> = ({ cards }) => {
   const tableTitleId = 'cuadros-comparativos-table-title';
   const descriptionId = 'cuadros-comparativos-table-description';
   const hasPeriodoColumn = cards.some((card) => Boolean(card.periodoLabel));
   const hasTendenciaColumn = cards.some((card) => Boolean(card.tendenciaLabel));
 
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = React.useState(1);
+
+  const filteredCards = React.useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+
+    if (!term) {
+      return cards;
+    }
+
+    return cards.filter((card) => {
+      const producto = card.producto.toLowerCase();
+      const periodo = card.periodoLabel?.toLowerCase() ?? '';
+      const tendencia = card.tendenciaLabel?.toLowerCase() ?? '';
+
+      return producto.includes(term) || periodo.includes(term) || tendencia.includes(term);
+    });
+  }, [cards, searchTerm]);
+
+  React.useEffect(() => {
+    setPage(1);
+  }, [searchTerm, pageSize, cards]);
+
+  const totalPages = React.useMemo(() => {
+    if (filteredCards.length === 0) {
+      return 1;
+    }
+
+    return Math.max(1, Math.ceil(filteredCards.length / pageSize));
+  }, [filteredCards.length, pageSize]);
+
+  React.useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
+
+  const paginatedCards = React.useMemo(() => {
+    const startIndex = (page - 1) * pageSize;
+    return filteredCards.slice(startIndex, startIndex + pageSize);
+  }, [filteredCards, page, pageSize]);
+
+  const normalizedPageSizeOptions = React.useMemo(() => {
+    const uniqueOptions = new Set([...PAGE_SIZE_OPTIONS, pageSize]);
+    return Array.from(uniqueOptions).sort((a, b) => a - b);
+  }, [pageSize]);
+
+  const hasResults = filteredCards.length > 0;
+  const from = hasResults ? (page - 1) * pageSize + 1 : 0;
+  const to = hasResults ? Math.min(page * pageSize, filteredCards.length) : 0;
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handlePageSizeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setPageSize(Number(event.target.value));
+  };
+
+  const handlePreviousPage = () => {
+    setPage((current) => Math.max(1, current - 1));
+  };
+
+  const handleNextPage = () => {
+    setPage((current) => Math.min(totalPages, current + 1));
+  };
+
+  const sectionClassName = `reportes-table-card${hasResults ? '' : ' reportes-table-card--empty'}`;
+  const displayPage = hasResults ? page : 0;
+  const displayTotalPages = hasResults ? totalPages : 0;
+
   return (
     <section
-      className="reportes-table-card"
+      className={sectionClassName}
       aria-labelledby={tableTitleId}
       aria-describedby={descriptionId}
     >
@@ -29,87 +104,151 @@ const CuadrosComparativos: React.FC<CuadrosComparativosProps> = ({ cards }) => {
         <p id={descriptionId}>Comparativo de costos directos e indirectos.</p>
       </header>
       <div className="reportes-table-card__body">
-        <div className="reportes-table-wrapper">
-          <table
-            className="reportes-table"
-            role="grid"
-            aria-label="Detalle de cuadros comparativos por producto"
-            aria-describedby={descriptionId}
-          >
-            <thead>
-              <tr>
-                <th scope="col" style={{ textAlign: 'left' }}>
-                  Producto
-                </th>
-                {hasPeriodoColumn && (
-                  <th scope="col" style={{ textAlign: 'left' }}>
-                    Periodo
-                  </th>
-                )}
-                <th scope="col" style={{ textAlign: 'right' }}>
-                  Costo directo
-                </th>
-                <th scope="col" style={{ textAlign: 'right' }}>
-                  Costo indirecto
-                </th>
-                <th scope="col" style={{ textAlign: 'right' }}>
-                  Diferencia
-                </th>
-                {hasTendenciaColumn && (
-                  <th scope="col" style={{ textAlign: 'left' }}>
-                    Tendencia
-                  </th>
-                )}
-              </tr>
-            </thead>
-            <tbody>
-              {cards.map((card) => (
-                <tr key={card.id} className={toneRowClassMap[card.tone]}>
-                  <th scope="row" className="reportes-table__cell reportes-table__cell--row-header">
-                    {card.producto}
-                  </th>
-                  {hasPeriodoColumn && (
-                    <td className="reportes-table__cell" data-column="Periodo">
-                      {card.periodoLabel ?? '—'}
-                    </td>
-                  )}
-                  <td
-                    className="reportes-table__cell"
-                    data-column="Costo directo"
-                    style={{ textAlign: 'right' }}
-                  >
-                    {card.costoDirecto}
-                  </td>
-                  <td
-                    className="reportes-table__cell"
-                    data-column="Costo indirecto"
-                    style={{ textAlign: 'right' }}
-                  >
-                    {card.costoIndirecto}
-                  </td>
-                  <td
-                    className="reportes-table__cell"
-                    data-column="Diferencia"
-                    style={{ textAlign: 'right' }}
-                  >
-                    <div className="reportes-cuadros-difference">
-                      <span className="reportes-cuadros-difference__value">{card.diferencia}</span>
-                      {card.diferenciaPorcentaje && (
-                        <span className="reportes-cuadros-difference__percentage">
-                          {card.diferenciaPorcentaje}
-                        </span>
+        <div className="reportes-cuadros-controls">
+          <div className="reportes-cuadros-filter-bar" role="search">
+            <div className="reportes-cuadros-filter-bar__field">
+              <label htmlFor="cuadros-comparativos-search" className="reportes-cuadros-filter-bar__label">
+                Búsqueda
+              </label>
+              <input
+                id="cuadros-comparativos-search"
+                type="search"
+                className="reportes-cuadros-filter-bar__input"
+                placeholder="Buscar por producto o periodo"
+                value={searchTerm}
+                onChange={handleSearchChange}
+              />
+            </div>
+          </div>
+
+          {hasResults ? (
+            <>
+              <div className="reportes-table-wrapper">
+                <table
+                  className="reportes-table"
+                  role="grid"
+                  aria-label="Detalle de cuadros comparativos por producto"
+                  aria-describedby={descriptionId}
+                >
+                  <thead>
+                    <tr>
+                      <th scope="col" style={{ textAlign: 'left' }}>
+                        Producto
+                      </th>
+                      {hasPeriodoColumn && (
+                        <th scope="col" style={{ textAlign: 'left' }}>
+                          Periodo
+                        </th>
                       )}
-                    </div>
-                  </td>
-                  {hasTendenciaColumn && (
-                    <td className="reportes-table__cell" data-column="Tendencia">
-                      {card.tendenciaLabel ?? '—'}
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                      <th scope="col" style={{ textAlign: 'right' }}>
+                        Costo directo
+                      </th>
+                      <th scope="col" style={{ textAlign: 'right' }}>
+                        Costo indirecto
+                      </th>
+                      <th scope="col" style={{ textAlign: 'right' }}>
+                        Diferencia
+                      </th>
+                      {hasTendenciaColumn && (
+                        <th scope="col" style={{ textAlign: 'left' }}>
+                          Tendencia
+                        </th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {paginatedCards.map((card) => (
+                      <tr key={card.id} className={toneRowClassMap[card.tone]}>
+                        <th scope="row" className="reportes-table__cell reportes-table__cell--row-header">
+                          {card.producto}
+                        </th>
+                        {hasPeriodoColumn && (
+                          <td className="reportes-table__cell" data-column="Periodo">
+                            {card.periodoLabel ?? '—'}
+                          </td>
+                        )}
+                        <td
+                          className="reportes-table__cell"
+                          data-column="Costo directo"
+                          style={{ textAlign: 'right' }}
+                        >
+                          {card.costoDirecto}
+                        </td>
+                        <td
+                          className="reportes-table__cell"
+                          data-column="Costo indirecto"
+                          style={{ textAlign: 'right' }}
+                        >
+                          {card.costoIndirecto}
+                        </td>
+                        <td
+                          className="reportes-table__cell"
+                          data-column="Diferencia"
+                          style={{ textAlign: 'right' }}
+                        >
+                          <div className="reportes-cuadros-difference">
+                            <span className="reportes-cuadros-difference__value">{card.diferencia}</span>
+                            {card.diferenciaPorcentaje && (
+                              <span className="reportes-cuadros-difference__percentage">
+                                {card.diferenciaPorcentaje}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        {hasTendenciaColumn && (
+                          <td className="reportes-table__cell" data-column="Tendencia">
+                            {card.tendenciaLabel ?? '—'}
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="reportes-cuadros-pagination" aria-label="Paginación de detalle por producto">
+                <span className="reportes-cuadros-pagination__info">
+                  Mostrando {from.toLocaleString()}-{to.toLocaleString()} de {filteredCards.length.toLocaleString()}
+                </span>
+                <div className="reportes-cuadros-pagination__actions">
+                  <label className="reportes-cuadros-pagination__page-size">
+                    Mostrar
+                    <select value={pageSize} onChange={handlePageSizeChange}>
+                      {normalizedPageSizeOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                    registros
+                  </label>
+                  <button
+                    type="button"
+                    className="secondary small"
+                    onClick={handlePreviousPage}
+                    disabled={page === 1}
+                  >
+                    Anterior
+                  </button>
+                  <span className="reportes-cuadros-pagination__page">
+                    Página {displayPage} de {displayTotalPages}
+                  </span>
+                  <button
+                    type="button"
+                    className="secondary small"
+                    onClick={handleNextPage}
+                    disabled={page === totalPages}
+                  >
+                    Siguiente
+                  </button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="reportes-empty-state" role="status">
+              <p>No se encontraron productos que coincidan con la búsqueda.</p>
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -299,6 +299,7 @@
   border: 1px solid var(--color-outline);
   border-radius: 12px;
   overflow: auto;
+  background: var(--color-surface-alt);
 }
 
 .reportes-table {
@@ -365,6 +366,107 @@
 
 .reportes-empty-state h4 {
   margin: 0 0 0.5rem;
+}
+
+.reportes-cuadros-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.reportes-cuadros-filter-bar {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.reportes-cuadros-filter-bar__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reportes-cuadros-filter-bar__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.reportes-cuadros-filter-bar__input {
+  border: 1px solid var(--color-outline);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  background: var(--color-surface-alt);
+  color: var(--color-text-primary);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.reportes-cuadros-filter-bar__input::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.reportes-cuadros-filter-bar__input:focus {
+  outline: 2px solid rgba(20, 94, 168, 0.35);
+  outline-offset: 2px;
+  border-color: rgba(20, 94, 168, 0.35);
+  box-shadow: 0 0 0 2px rgba(20, 94, 168, 0.08);
+}
+
+.reportes-cuadros-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.reportes-cuadros-pagination__info {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.reportes-cuadros-pagination__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.reportes-cuadros-pagination__page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.reportes-cuadros-pagination__page-size select {
+  border: 1px solid var(--color-outline);
+  border-radius: 8px;
+  padding: 6px 10px;
+  background: var(--color-surface-alt);
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+.reportes-cuadros-pagination__page {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .reportes-cuadros-pagination {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .reportes-cuadros-pagination__actions {
+    justify-content: space-between;
+  }
 }
 
 .reportes-export-bar {


### PR DESCRIPTION
## Summary
- add search filtering, pagination, and page size controls to the Detalle por producto report table to mirror catalog tables
- style the report table controls and container so the experience matches the Actividades table, including a white background

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68efc86c57688330a7392bd47ba747e7