### PR TITLE
feat: make report sections collapsible

### DIFF
--- a/frontend-app/src/modules/reportes/components/ReportSection.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportSection.tsx
@@ -1,23 +1,58 @@
-import React from 'react';
+import React, { useId, useState } from 'react';
 
 interface ReportSectionProps {
   title: string;
   description: string;
   actions?: React.ReactNode;
   children: React.ReactNode;
+  defaultCollapsed?: boolean;
 }
 
-const ReportSection: React.FC<ReportSectionProps> = ({ title, description, actions, children }) => (
-  <section className="reportes-module__section">
-    <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
-      <div>
-        <h3>{title}</h3>
-        <p>{description}</p>
+const ReportSection: React.FC<ReportSectionProps> = ({
+  title,
+  description,
+  actions,
+  children,
+  defaultCollapsed = false,
+}) => {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const contentId = useId();
+
+  const toggleLabel = collapsed ? 'Expandir sección' : 'Contraer sección';
+
+  return (
+    <section
+      className={`reportes-module__section${collapsed ? ' reportes-module__section--collapsed' : ''}`}
+    >
+      <header className="reportes-module__section-header">
+        <div className="reportes-module__section-header-content">
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+        {actions && <div className="reportes-module__section-actions">{actions}</div>}
+        <button
+          type="button"
+          className="reportes-module__section-toggle"
+          aria-expanded={!collapsed}
+          aria-controls={contentId}
+          onClick={() => setCollapsed((value) => !value)}
+        >
+          <span className="sr-only">{toggleLabel}</span>
+          <svg
+            className="reportes-module__section-toggle-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
+      </header>
+      <div id={contentId} hidden={collapsed} className="reportes-module__section-body">
+        {children}
       </div>
-      {actions && <div>{actions}</div>}
-    </header>
-    <div>{children}</div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default ReportSection;

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -123,6 +123,58 @@
   border: 1px solid rgba(15, 23, 42, 0.08);
 }
 
+.reportes-module__section-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.reportes-module__section-header-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.reportes-module__section-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reportes-module__section-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: linear-gradient(135deg, rgba(241, 245, 249, 0.95), rgba(226, 232, 240, 0.8));
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.reportes-module__section-toggle:hover,
+.reportes-module__section-toggle:focus-visible {
+  border-color: rgba(14, 165, 233, 0.6);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.4);
+  outline: none;
+}
+
+.reportes-module__section-toggle-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  transition: transform 0.2s ease;
+}
+
+.reportes-module__section--collapsed .reportes-module__section-toggle-icon {
+  transform: rotate(-90deg);
+}
+
+.reportes-module__section-body {
+  margin-top: 1.5rem;
+}
+
 .reportes-module__section h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- add internal state to report sections so financial report modules can be collapsed or expanded on demand
- introduce shared layout and toggle styling that matches the collapsible design across the report cards

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efc9848ad0833091f3aee63e10ce93