### PR TITLE
Adjust report table tone styling

### DIFF
--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -286,21 +286,21 @@
 }
 
 .reportes-table tbody tr.reportes-cuadros-row--success .reportes-table__cell {
-  box-shadow: inset 4px 0 rgba(13, 148, 136, 0.6);
+  background: rgba(13, 148, 136, 0.08);
 }
 
 .reportes-table tbody tr.reportes-cuadros-row--warning .reportes-table__cell {
-  box-shadow: inset 4px 0 rgba(234, 179, 8, 0.75);
+  background: rgba(234, 179, 8, 0.08);
 }
 
 .reportes-table tbody tr.reportes-cuadros-row--danger .reportes-table__cell {
-  box-shadow: inset 4px 0 rgba(249, 115, 22, 0.75);
+  background: rgba(249, 115, 22, 0.08);
 }
 
 .reportes-table tbody tr.reportes-cuadros-row--success:hover .reportes-table__cell,
 .reportes-table tbody tr.reportes-cuadros-row--warning:hover .reportes-table__cell,
 .reportes-table tbody tr.reportes-cuadros-row--danger:hover .reportes-table__cell {
-  background: rgba(20, 94, 168, 0.06);
+  background: rgba(15, 23, 42, 0.06);
 }
 
 .reportes-table-card {


### PR DESCRIPTION
## Summary
- replace the inset tone shadows in report comparison tables with soft background fills to remove orange separators

## Testing
- npm run lint *(fails: missing ESLint dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efcc58cee4833095702af13b309cfa