### PR TITLE
Use date picker for depreciation period input

### DIFF
--- a/frontend-app/src/modules/costos/components/RegisterDepreciationDialog.tsx
+++ b/frontend-app/src/modules/costos/components/RegisterDepreciationDialog.tsx
@@ -225,15 +225,7 @@ const RegisterDepreciationDialog: React.FC<RegisterDepreciationDialogProps> = ({
           </label>
           <label className="costos-field">
             <span>Periodo</span>
-            <input
-              type="text"
-              name="periodo"
-              value={formState.periodo}
-              onChange={handleChange}
-              placeholder="AAAA-MM"
-              pattern="\\d{4}-\\d{2}"
-              required
-            />
+            <input type="date" name="periodo" value={formState.periodo} onChange={handleChange} required />
           </label>
           {submitError && (
             <p className="costos-error" role="alert">


### PR DESCRIPTION
## Summary
- align the depreciation period field with the calculation date input by switching it to the date picker control

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68efeea25b508330a29382efcc125b06