### PR TITLE
Add existencias and asiento control API services

### DIFF
--- a/frontend-app/src/modules/existencias/services/asiento-control.service.ts
+++ b/frontend-app/src/modules/existencias/services/asiento-control.service.ts
@@ -1,0 +1,179 @@
+import apiClient from '@/lib/http/apiClient';
+import type { AsientoControl, CreateAsientoControlPayload } from '../types';
+
+interface RequestOptions {
+  signal?: AbortSignal;
+  usuario?: string;
+}
+
+type RawRecord = Record<string, unknown>;
+
+const ID_CANDIDATES = ['_id', 'id', 'ID', 'asientoId', 'idAsiento'];
+const FECHA_CANDIDATES = ['fecha', 'date', 'fechaAsiento'];
+const DEBITO_CANDIDATES = ['debitos', 'debito', 'totalDebitos'];
+const CREDITO_CANDIDATES = ['creditos', 'credito', 'totalCreditos'];
+const ACCESS_ID_CANDIDATES = ['accessId', 'AccessId', 'ACCESSID'];
+const CREATED_BY_CANDIDATES = ['createdBy', 'usuario', 'user'];
+const CREATED_AT_CANDIDATES = ['createdAt', 'fechaRegistro'];
+
+function parseNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return 0;
+
+    const normalized = trimmed.replace(/\s+/g, '');
+    const commaIndex = normalized.lastIndexOf(',');
+    const dotIndex = normalized.lastIndexOf('.');
+
+    let sanitized = normalized;
+    if (commaIndex > dotIndex) {
+      sanitized = sanitized.replace(/\./g, '').replace(/,/g, '.');
+    } else {
+      sanitized = sanitized.replace(/,/g, '');
+    }
+
+    const parsed = Number.parseFloat(sanitized);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  return 0;
+}
+
+function ensureId(raw: RawRecord): string {
+  for (const key of ID_CANDIDATES) {
+    const value = raw[key];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+  const dynamic = Object.keys(raw).find((key) => /^id/i.test(key));
+  if (dynamic) {
+    const value = raw[dynamic];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+  return `tmp-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+function pickString(raw: RawRecord, candidates: string[]): string | undefined {
+  for (const candidate of candidates) {
+    const value = raw[candidate];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+  const normalizedCandidates = candidates.map((candidate) => candidate.toLowerCase());
+  const dynamicKey = Object.keys(raw).find((key) => normalizedCandidates.includes(key.toLowerCase()));
+  if (dynamicKey) {
+    const value = raw[dynamicKey];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function normalizeDate(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function normalizeAsiento(raw: RawRecord): AsientoControl {
+  return {
+    id: ensureId(raw),
+    debitos: parseNumber(pickField(raw, DEBITO_CANDIDATES)),
+    creditos: parseNumber(pickField(raw, CREDITO_CANDIDATES)),
+    fecha: normalizeDate(pickField(raw, FECHA_CANDIDATES)) ?? new Date().toISOString(),
+    accessId: pickString(raw, ACCESS_ID_CANDIDATES),
+    createdBy: pickString(raw, CREATED_BY_CANDIDATES),
+    createdAt: normalizeDate(pickField(raw, CREATED_AT_CANDIDATES)),
+  };
+}
+
+function pickField(raw: RawRecord, candidates: string[]): unknown {
+  for (const candidate of candidates) {
+    if (candidate in raw) {
+      return raw[candidate];
+    }
+  }
+  const normalizedCandidates = candidates.map((candidate) => candidate.toLowerCase());
+  const dynamicKey = Object.keys(raw).find((key) => normalizedCandidates.includes(key.toLowerCase()));
+  if (dynamicKey) {
+    return raw[dynamicKey];
+  }
+  return undefined;
+}
+
+export async function listAsientosControl(options: RequestOptions = {}): Promise<AsientoControl[]> {
+  const response = await apiClient.get<unknown>('/api/asientos-control', {
+    signal: options.signal,
+  });
+
+  const asientos: RawRecord[] = [];
+
+  if (Array.isArray(response)) {
+    for (const item of response) {
+      if (item && typeof item === 'object') {
+        asientos.push(item as RawRecord);
+      }
+    }
+  } else if (response && typeof response === 'object') {
+    const data = response as Record<string, unknown>;
+    const candidateArrays = [data.items, data.data, data.results];
+    const array = candidateArrays.find((value): value is unknown[] => Array.isArray(value));
+
+    if (array) {
+      for (const item of array) {
+        if (item && typeof item === 'object') {
+          asientos.push(item as RawRecord);
+        }
+      }
+    } else {
+      asientos.push(data as RawRecord);
+    }
+  }
+
+  return asientos.map(normalizeAsiento).sort((a, b) => (a.fecha > b.fecha ? -1 : 1));
+}
+
+export async function crearAsientoControl(
+  payload: CreateAsientoControlPayload,
+  options: RequestOptions = {},
+): Promise<AsientoControl> {
+  const headers = options.usuario ? { 'x-user': options.usuario } : undefined;
+  const response = await apiClient.post<unknown, CreateAsientoControlPayload>('/api/asientos-control', payload, {
+    headers,
+    signal: options.signal,
+  });
+
+  if (!response || typeof response !== 'object') {
+    return {
+      id: `tmp-${Math.random().toString(36).slice(2, 11)}`,
+      debitos: payload.debitos,
+      creditos: payload.creditos,
+      fecha: normalizeDate(payload.fecha) ?? new Date().toISOString(),
+      accessId: payload.accessId,
+    };
+  }
+
+  return normalizeAsiento(response as RawRecord);
+}

--- a/frontend-app/src/modules/existencias/services/existencias.service.ts
+++ b/frontend-app/src/modules/existencias/services/existencias.service.ts
@@ -1,0 +1,290 @@
+import apiClient from '@/lib/http/apiClient';
+import type {
+  ConsolidarExistenciasPayload,
+  ExistenciaInicialPayload,
+  ExistenciaRecord,
+  ExistenciasBalance,
+  ExistenciasResumen,
+} from '../types';
+
+interface RequestOptions {
+  signal?: AbortSignal;
+  usuario?: string;
+}
+
+type RawRecord = Record<string, unknown>;
+
+type RawResponse =
+  | RawRecord
+  | RawRecord[]
+  | {
+      existencias?: unknown;
+      items?: unknown;
+      data?: unknown;
+      balance?: unknown;
+      asientos?: unknown;
+      resumen?: unknown;
+      meta?: Record<string, unknown>;
+      lastConsolidatedAt?: unknown;
+    };
+
+const ID_CANDIDATES = [
+  '_id',
+  'id',
+  'Id',
+  'ID',
+  'idExistencia',
+  'existenciaId',
+  'IDExistencia',
+];
+
+const PRODUCT_CANDIDATES = ['producto', 'Producto', 'sku', 'SKU', 'nombre'];
+const INITIAL_CANDIDATES = ['cantidadInicial', 'cantidad_inicial', 'inicial', 'cantidadIni'];
+const PRODUCCION_CANDIDATES = ['produccion', 'production', 'cantProd', 'cantidadProduccion'];
+const VENTAS_CANDIDATES = ['ventas', 'sales', 'cantVenta', 'cantidadVentas'];
+const PERDIDAS_CANDIDATES = ['perdidas', 'losses', 'cantPerdida', 'cantidadPerdidas'];
+const SOBRANTES_CANDIDATES = ['sobrantes', 'surplus', 'cantSobrante', 'cantidadSobrantes'];
+const FINAL_CANDIDATES = ['cantidadFinal', 'final', 'cantidad_fin', 'saldo'];
+const CALCULATION_DATE_CANDIDATES = ['calculationDate', 'fechaCalculo', 'calculo', 'periodo'];
+const UPDATED_AT_CANDIDATES = ['updatedAt', 'lastUpdatedAt', 'fechaActualizacion'];
+const ACCESS_ID_CANDIDATES = ['accessId', 'AccessId', 'ACCESSID'];
+
+function ensureId(raw: RawRecord): string {
+  for (const key of ID_CANDIDATES) {
+    const value = raw[key];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+
+  const dynamicKey = Object.keys(raw).find((key) => /^id/i.test(key));
+  if (dynamicKey) {
+    const value = raw[dynamicKey];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+
+  return `tmp-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+function pickString(raw: RawRecord, candidates: string[], fallback?: string): string | undefined {
+  for (const candidate of candidates) {
+    const value = raw[candidate];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+
+  const normalizedCandidates = candidates.map((candidate) => candidate.toLowerCase());
+  const matchingKey = Object.keys(raw).find((key) => normalizedCandidates.includes(key.toLowerCase()));
+  if (matchingKey) {
+    const value = raw[matchingKey];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+
+  return fallback;
+}
+
+function parseNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return 0;
+
+    const normalized = trimmed.replace(/\s+/g, '');
+    const commaIndex = normalized.lastIndexOf(',');
+    const dotIndex = normalized.lastIndexOf('.');
+
+    let sanitized = normalized;
+    if (commaIndex > dotIndex) {
+      sanitized = sanitized.replace(/\./g, '').replace(/,/g, '.');
+    } else {
+      sanitized = sanitized.replace(/,/g, '');
+    }
+
+    const parsed = Number.parseFloat(sanitized);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+
+  return 0;
+}
+
+function pickNumber(raw: RawRecord, candidates: string[]): number {
+  for (const candidate of candidates) {
+    if (candidate in raw) {
+      return parseNumber(raw[candidate]);
+    }
+  }
+
+  const normalizedCandidates = candidates.map((candidate) => candidate.toLowerCase());
+  const matchingKey = Object.keys(raw).find((key) => normalizedCandidates.includes(key.toLowerCase()));
+  if (matchingKey) {
+    return parseNumber(raw[matchingKey]);
+  }
+
+  return 0;
+}
+
+function normalizeDate(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString();
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function normalizeExistencia(raw: RawRecord): ExistenciaRecord {
+  return {
+    id: ensureId(raw),
+    producto: pickString(raw, PRODUCT_CANDIDATES) ?? '',
+    cantidadInicial: pickNumber(raw, INITIAL_CANDIDATES),
+    produccion: pickNumber(raw, PRODUCCION_CANDIDATES),
+    ventas: pickNumber(raw, VENTAS_CANDIDATES),
+    perdidas: pickNumber(raw, PERDIDAS_CANDIDATES),
+    sobrantes: pickNumber(raw, SOBRANTES_CANDIDATES),
+    cantidadFinal: pickNumber(raw, FINAL_CANDIDATES),
+    accessId: pickString(raw, ACCESS_ID_CANDIDATES),
+    calculationDate: normalizeDate(pickString(raw, CALCULATION_DATE_CANDIDATES)),
+    lastUpdatedAt: normalizeDate(pickString(raw, UPDATED_AT_CANDIDATES)),
+  };
+}
+
+function extractExistencias(response: RawResponse): RawRecord[] {
+  if (Array.isArray(response)) {
+    return response.filter((item): item is RawRecord => item && typeof item === 'object');
+  }
+
+  if (response && typeof response === 'object') {
+    const candidateArrays = [response.existencias, response.items, response.data, response.results];
+    const array = candidateArrays.find((value): value is unknown[] => Array.isArray(value));
+    if (array) {
+      return array.filter((item): item is RawRecord => item && typeof item === 'object');
+    }
+  }
+
+  return [];
+}
+
+function extractBalance(response: RawResponse): ExistenciasBalance {
+  if (response && typeof response === 'object') {
+    const sources = [response.balance, response.asientos, response.resumen, response.meta];
+    for (const source of sources) {
+      if (source && typeof source === 'object') {
+        const data = source as RawRecord;
+        const debitos = pickNumber(data, ['debitos', 'debito', 'totalDebitos']);
+        const creditos = pickNumber(data, ['creditos', 'credito', 'totalCreditos']);
+        const diferenciaCandidate = data.diferencia ?? data.difference ?? data.balance;
+        const diferencia = parseNumber(diferenciaCandidate);
+        return {
+          debitos,
+          creditos,
+          diferencia: diferencia || Number((debitos - creditos).toFixed(2)),
+        };
+      }
+    }
+  }
+
+  return {
+    debitos: 0,
+    creditos: 0,
+    diferencia: 0,
+  };
+}
+
+function extractLastConsolidatedAt(response: RawResponse): string | undefined {
+  if (!response || typeof response !== 'object') return undefined;
+  if (typeof response.lastConsolidatedAt === 'string') {
+    return normalizeDate(response.lastConsolidatedAt) ?? undefined;
+  }
+  if (response.meta && typeof response.meta === 'object') {
+    const meta = response.meta as RawRecord;
+    if (typeof meta.lastConsolidatedAt === 'string') {
+      return normalizeDate(meta.lastConsolidatedAt) ?? undefined;
+    }
+    if (typeof meta.updatedAt === 'string') {
+      return normalizeDate(meta.updatedAt) ?? undefined;
+    }
+  }
+  return undefined;
+}
+
+export async function fetchExistenciasResumen(options: RequestOptions = {}): Promise<ExistenciasResumen> {
+  const response = await apiClient.get<RawResponse>('/api/existencias', {
+    signal: options.signal,
+  });
+
+  const existencias = extractExistencias(response).map(normalizeExistencia);
+  const balance = extractBalance(response);
+  const lastConsolidatedAt = extractLastConsolidatedAt(response);
+
+  return {
+    existencias,
+    balance,
+    totalProductos: existencias.length,
+    lastConsolidatedAt,
+  };
+}
+
+export async function registrarExistenciasIniciales(
+  existencias: ExistenciaInicialPayload[],
+  options: RequestOptions = {},
+): Promise<{ message?: string } | null> {
+  const headers = options.usuario ? { 'x-user': options.usuario } : undefined;
+  const response = await apiClient.post<Record<string, unknown> | null, ExistenciaInicialPayload[]>(
+    '/api/existencias',
+    existencias,
+    {
+      headers,
+      signal: options.signal,
+    },
+  );
+
+  if (response && typeof response === 'object') {
+    const message = 'message' in response ? String(response.message) : undefined;
+    return message ? { message } : response;
+  }
+
+  return null;
+}
+
+export async function consolidarExistencias(
+  payload: ConsolidarExistenciasPayload = {},
+  options: RequestOptions = {},
+): Promise<{ message?: string } | null> {
+  const headers = options.usuario ? { 'x-user': options.usuario } : undefined;
+  const response = await apiClient.post<Record<string, unknown> | null, ConsolidarExistenciasPayload>(
+    '/api/existencias/consolidar',
+    payload,
+    {
+      headers,
+      signal: options.signal,
+    },
+  );
+
+  if (response && typeof response === 'object') {
+    const message = 'message' in response ? String(response.message) : undefined;
+    return message ? { message } : response;
+  }
+
+  return null;
+}

--- a/frontend-app/src/modules/existencias/types.ts
+++ b/frontend-app/src/modules/existencias/types.ts
@@ -1,0 +1,53 @@
+export interface ExistenciaRecord {
+  id: string;
+  producto: string;
+  cantidadInicial: number;
+  produccion: number;
+  ventas: number;
+  perdidas: number;
+  sobrantes: number;
+  cantidadFinal: number;
+  accessId?: string;
+  calculationDate?: string;
+  lastUpdatedAt?: string;
+}
+
+export interface ExistenciasBalance {
+  debitos: number;
+  creditos: number;
+  diferencia: number;
+}
+
+export interface ExistenciasResumen {
+  existencias: ExistenciaRecord[];
+  balance: ExistenciasBalance;
+  totalProductos: number;
+  lastConsolidatedAt?: string;
+}
+
+export interface ExistenciaInicialPayload {
+  producto: string;
+  cantidad: number;
+  accessId?: string;
+}
+
+export interface ConsolidarExistenciasPayload {
+  fecha?: string;
+}
+
+export interface AsientoControl {
+  id: string;
+  debitos: number;
+  creditos: number;
+  fecha: string;
+  accessId?: string;
+  createdBy?: string;
+  createdAt?: string;
+}
+
+export interface CreateAsientoControlPayload {
+  debitos: number;
+  creditos: number;
+  fecha?: string;
+  accessId?: string;
+}


### PR DESCRIPTION
## Summary
- add shared types for existencias records, balances, and asientos de control
- implement existencias service covering fetch, registro inicial y consolidación with robust normalization
- expose asiento de control service for listing and creating records including audit headers

## Testing
- npm run lint *(fails: missing @eslint/js package in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f072923aa88330adccc395a80393be