### PR TITLE
feat: highlight pesos as base currency in costos module

### DIFF
--- a/frontend-app/src/lib/formatters.ts
+++ b/frontend-app/src/lib/formatters.ts
@@ -15,6 +15,16 @@ export function formatCurrency(value: number, options: FormatCurrencyOptions = {
   }).format(Number.isFinite(value) ? value : 0);
 }
 
+export function getCurrencySymbol(currency: string, locale = 'es-MX'): string {
+  try {
+    const formatter = new Intl.NumberFormat(locale, { style: 'currency', currency });
+    const symbol = formatter.formatToParts(0).find((part) => part.type === 'currency');
+    return symbol?.value ?? currency;
+  } catch {
+    return currency;
+  }
+}
+
 export interface FormatPercentageOptions {
   locale?: string;
   minimumFractionDigits?: number;

--- a/frontend-app/src/modules/costos/components/BalanceSummary.tsx
+++ b/frontend-app/src/modules/costos/components/BalanceSummary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatCurrency } from '@/lib/formatters';
 import type { BalanceSummaryData } from '../types';
 import '../costos.css';
 
@@ -67,8 +68,8 @@ const BalanceSummary: React.FC<BalanceSummaryProps> = ({ summary, formatted, onR
     )}
 
     <footer className="costos-metadata">
-      <span>Balance: {summary.balance.toLocaleString('es-MX', { minimumFractionDigits: 2 })}</span>
-      <span>Diferencia: {summary.difference.toLocaleString('es-MX', { minimumFractionDigits: 2 })}</span>
+      <span>Balance: {formatCurrency(summary.balance, { currency: summary.currency })}</span>
+      <span>Diferencia: {formatCurrency(summary.difference, { currency: summary.currency })}</span>
     </footer>
   </section>
 );

--- a/frontend-app/src/modules/costos/components/CostosLayout.tsx
+++ b/frontend-app/src/modules/costos/components/CostosLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import apiClient from '@/lib/http/apiClient';
+import { getCurrencySymbol } from '@/lib/formatters';
 import CostosTabs from './CostosTabs';
 import CostosFilterBar from './CostosFilterBar';
 import CostosDataTable from './CostosDataTable';
@@ -73,6 +74,7 @@ const CostosLayout: React.FC = () => {
 
   const headerDescription =
     'Calcula, distribuye y consolida costos operativos asegurando trazabilidad entre centros, existencias y asientos.';
+  const baseCurrencySymbol = useMemo(() => getCurrencySymbol(summary.currency), [summary.currency]);
 
   const navigationDisabledMessage =
     'Disponible cuando se habilite la navegación directa hacia Existencias y Asientos.';
@@ -165,6 +167,13 @@ const CostosLayout: React.FC = () => {
         <div>
           <h1>Costos y consolidaciones</h1>
           <p>{headerDescription}</p>
+          <div className="costos-base-currency" aria-live="polite">
+            <span className="costos-base-currency__label">Moneda base</span>
+            <span className="costos-base-currency__symbol" aria-hidden="true">
+              {baseCurrencySymbol}
+            </span>
+            <span className="costos-base-currency__code">{summary.currency}</span>
+          </div>
         </div>
         <div className="costos-actions">
           <button type="button" className="primary" onClick={() => setDialogOpen(true)}>
@@ -305,7 +314,7 @@ const CostosLayout: React.FC = () => {
             isLoading={query.status === 'loading'}
           />
           <AllocationBreakdown items={allocation} currency={summary.currency} />
-          <TrendChart points={trend} />
+          <TrendChart points={trend} currency={summary.currency} />
           <AuditTimeline record={selected} />
           <ProcessLog logs={processState.logs} />
         </div>

--- a/frontend-app/src/modules/costos/components/ProcessRunnerDialog.tsx
+++ b/frontend-app/src/modules/costos/components/ProcessRunnerDialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatCurrency } from '@/lib/formatters';
 import type { BalanceSummaryData, CostosProcessState } from '../types';
 import '../costos.css';
 
@@ -32,6 +33,9 @@ const ProcessRunnerDialog: React.FC<ProcessRunnerDialogProps> = ({
 }) => {
   if (!open) return null;
 
+  const currency = latestSummary?.currency ?? 'MXN';
+  const formatProcessAmount = (value: number) => formatCurrency(value, { currency });
+
   const simulatedResult =
     process.result ??
     (latestSummary
@@ -57,8 +61,8 @@ const ProcessRunnerDialog: React.FC<ProcessRunnerDialogProps> = ({
             <strong>Estado: {statusLabel[process.status]}</strong>
             {simulatedResult && (
               <p className="costos-metadata">
-                Balance: {simulatedResult.balance.toLocaleString('es-MX', { minimumFractionDigits: 2 })} · Diferencia:{' '}
-                {simulatedResult.difference.toLocaleString('es-MX', { minimumFractionDigits: 2 })}
+                Balance: {formatProcessAmount(simulatedResult.balance)} · Diferencia:{' '}
+                {formatProcessAmount(simulatedResult.difference)}
               </p>
             )}
             {simulatedResult?.warning && <p className="costos-warning">{simulatedResult.warning}</p>}

--- a/frontend-app/src/modules/costos/components/TrendChart.tsx
+++ b/frontend-app/src/modules/costos/components/TrendChart.tsx
@@ -1,12 +1,15 @@
 import React, { useMemo } from 'react';
+import { formatCurrency } from '@/lib/formatters';
 import type { TrendPoint } from '../types';
 import '../costos.css';
 
 interface TrendChartProps {
   points: TrendPoint[];
+  currency: string;
 }
 
-const TrendChart: React.FC<TrendChartProps> = ({ points }) => {
+const TrendChart: React.FC<TrendChartProps> = ({ points, currency }) => {
+  const resolvedCurrency = currency || 'MXN';
   const { path, min, max } = useMemo(() => {
     if (points.length === 0) {
       return { path: '', min: 0, max: 0 };
@@ -47,8 +50,8 @@ const TrendChart: React.FC<TrendChartProps> = ({ points }) => {
             })}
           </svg>
           <div className="costos-metadata">
-            <span>Valor mínimo: {min.toLocaleString('es-MX', { minimumFractionDigits: 2 })}</span>
-            <span>Valor máximo: {max.toLocaleString('es-MX', { minimumFractionDigits: 2 })}</span>
+            <span>Valor mínimo: {formatCurrency(min, { currency: resolvedCurrency })}</span>
+            <span>Valor máximo: {formatCurrency(max, { currency: resolvedCurrency })}</span>
           </div>
         </div>
       )}

--- a/frontend-app/src/modules/costos/costos.css
+++ b/frontend-app/src/modules/costos/costos.css
@@ -24,6 +24,35 @@
   max-width: 720px;
 }
 
+.costos-base-currency {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  background: rgba(20, 94, 168, 0.12);
+  color: var(--color-primary-variant);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.costos-base-currency__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: rgba(20, 94, 168, 0.72);
+}
+
+.costos-base-currency__symbol {
+  font-size: 1rem;
+}
+
+.costos-base-currency__code {
+  font-size: 0.78rem;
+  color: rgba(20, 94, 168, 0.72);
+}
+
 .costos-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- show the pesos base currency badge in the Costos module header
- reuse the shared currency formatter for balance, process, and trend metrics
- add a helper to derive currency symbols and styles for the badge

## Testing
- npm run lint *(fails: registry returned 403 for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f29fa36ebc83308618c49ad457cbef