### PR TITLE
Update frontend currency formatting to Argentine pesos

### DIFF
--- a/frontend-app/src/lib/formatters.ts
+++ b/frontend-app/src/lib/formatters.ts
@@ -6,7 +6,7 @@ export interface FormatCurrencyOptions {
 }
 
 export function formatCurrency(value: number, options: FormatCurrencyOptions = {}): string {
-  const { currency = 'MXN', locale = 'es-MX', minimumFractionDigits = 2, maximumFractionDigits = 2 } = options;
+  const { currency = 'ARS', locale = 'es-AR', minimumFractionDigits = 2, maximumFractionDigits = 2 } = options;
   return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
@@ -15,7 +15,7 @@ export function formatCurrency(value: number, options: FormatCurrencyOptions = {
   }).format(Number.isFinite(value) ? value : 0);
 }
 
-export function getCurrencySymbol(currency: string, locale = 'es-MX'): string {
+export function getCurrencySymbol(currency: string, locale = 'es-AR'): string {
   try {
     const formatter = new Intl.NumberFormat(locale, { style: 'currency', currency });
     const symbol = formatter.formatToParts(0).find((part) => part.type === 'currency');

--- a/frontend-app/src/modules/configuracion/hooks/useCentrosApoyo.ts
+++ b/frontend-app/src/modules/configuracion/hooks/useCentrosApoyo.ts
@@ -141,7 +141,7 @@ export async function listCentroApoyoGastos(
   let items: unknown[] = [];
   let total = 0;
   let count = 0;
-  let currency = 'MXN';
+  let currency = 'ARS';
 
   if (Array.isArray(response)) {
     items = response;

--- a/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
@@ -116,7 +116,7 @@ const CentrosApoyoPage: React.FC = () => {
   const [gastosSummary, setGastosSummary] = useState<CentroApoyoExpenseSummary>(() =>
     buildCentrosApoyoSummary([]),
   );
-  const [gastosCurrency, setGastosCurrency] = useState('MXN');
+  const [gastosCurrency, setGastosCurrency] = useState('ARS');
   const [gastosLoading, setGastosLoading] = useState(false);
   const [gastosError, setGastosError] = useState<string | null>(null);
   const [gastosWarning, setGastosWarning] = useState<string | null>(null);

--- a/frontend-app/src/modules/costos/__tests__/transformers.test.ts
+++ b/frontend-app/src/modules/costos/__tests__/transformers.test.ts
@@ -53,7 +53,7 @@ test('calculateBalanceSummary calcula variación porcentual', () => {
     difference: 50,
     previousTotal: 800,
     warning: null,
-    currency: 'MXN',
+    currency: 'ARS',
     history: [],
   };
 

--- a/frontend-app/src/modules/costos/api/costosApi.ts
+++ b/frontend-app/src/modules/costos/api/costosApi.ts
@@ -85,7 +85,7 @@ export async function fetchCostosList<K extends Exclude<CostosSubModulo, 'prorra
   let previousTotal: number | undefined;
   let totalAmount: number | undefined;
   let totalCount: number | undefined;
-  let currency = 'MXN';
+  let currency = 'ARS';
   let history: { period: string; totalAmount: number }[] = [];
 
   if (Array.isArray(response)) {

--- a/frontend-app/src/modules/costos/components/ProcessRunnerDialog.tsx
+++ b/frontend-app/src/modules/costos/components/ProcessRunnerDialog.tsx
@@ -33,7 +33,7 @@ const ProcessRunnerDialog: React.FC<ProcessRunnerDialogProps> = ({
 }) => {
   if (!open) return null;
 
-  const currency = latestSummary?.currency ?? 'MXN';
+  const currency = latestSummary?.currency ?? 'ARS';
   const formatProcessAmount = (value: number) => formatCurrency(value, { currency });
 
   const simulatedResult =

--- a/frontend-app/src/modules/costos/components/TrendChart.tsx
+++ b/frontend-app/src/modules/costos/components/TrendChart.tsx
@@ -9,7 +9,7 @@ interface TrendChartProps {
 }
 
 const TrendChart: React.FC<TrendChartProps> = ({ points, currency }) => {
-  const resolvedCurrency = currency || 'MXN';
+  const resolvedCurrency = currency || 'ARS';
   const { path, min, max } = useMemo(() => {
     if (points.length === 0) {
       return { path: '', min: 0, max: 0 };

--- a/frontend-app/src/modules/costos/utils/transformers.ts
+++ b/frontend-app/src/modules/costos/utils/transformers.ts
@@ -192,7 +192,7 @@ export function calculateBalanceSummary(
       balance: 0,
       variationPercentage: 0,
       warning: undefined,
-      currency: 'MXN',
+      currency: 'ARS',
     };
   }
   const previous = response.previousTotal ?? 0;

--- a/frontend-app/src/modules/reportes/api/reportesApi.ts
+++ b/frontend-app/src/modules/reportes/api/reportesApi.ts
@@ -57,7 +57,7 @@ export async function fetchCostosReport(filters: ReportFilters): Promise<FetchCo
     ],
     rows: normalized.costos.map((item) => ({
       centro: item.centro,
-      monto: new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(item.monto),
+      monto: new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(item.monto),
     })),
     emptyMessage: 'Sin registros de costos para el periodo solicitado.',
   };
@@ -72,7 +72,7 @@ export async function fetchCostosReport(filters: ReportFilters): Promise<FetchCo
     ],
     rows: normalized.consumos.map((item) => ({
       producto: item.producto,
-      cantidad: new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+      cantidad: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
         item.cantidad,
       ),
     })),

--- a/frontend-app/src/modules/reportes/components/ComparisonChart.tsx
+++ b/frontend-app/src/modules/reportes/components/ComparisonChart.tsx
@@ -23,10 +23,10 @@ const ComparisonChart: React.FC<ComparisonChartProps> = ({ data, insight }) => (
         <BarChart data={data} barGap={12} role="img" aria-label="Gráfico comparativo de egresos e insumos">
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
-          <YAxis tickFormatter={(value) => new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(value)} />
+          <YAxis tickFormatter={(value) => new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(value)} />
           <Tooltip
             formatter={(value: number) =>
-              new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(value)
+              new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(value)
             }
             contentStyle={{ backgroundColor: '#0f172a', color: '#f8fafc', borderRadius: 12 }}
           />


### PR DESCRIPTION
## Summary
- replace MXN currency defaults with ARS across report and costos modules
- adjust shared formatter defaults to use the Argentine locale
- keep configuration flows in sync with the new peso currency

## Testing
- npm test *(fails: requires npm dependencies that cannot be installed due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a35fbf0083308f82f11f69cffe5a