### PR TITLE
Add search and pagination controls to CIF report table

### DIFF
--- a/frontend-app/src/modules/reportes/components/ReportTable.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportTable.tsx
@@ -21,6 +21,92 @@ const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: Report
   const hasRows = descriptor.rows && descriptor.rows.length > 0;
   const titleId = `${descriptor.id}-title`;
   const descriptionId = descriptor.description ? `${descriptor.id}-description` : undefined;
+  const searchId = `${descriptor.id}-search`;
+
+  const enableSearch = Boolean(descriptor.enableSearch);
+  const enablePagination = Boolean(descriptor.enablePagination);
+
+  const pageSizeOptions = React.useMemo(() => {
+    if (!enablePagination) {
+      return [];
+    }
+
+    const options = new Set<number>();
+    (descriptor.pageSizeOptions ?? []).forEach((option) => {
+      if (typeof option === 'number' && Number.isFinite(option) && option > 0) {
+        options.add(Math.floor(option));
+      }
+    });
+
+    if (descriptor.defaultPageSize && Number.isFinite(descriptor.defaultPageSize) && descriptor.defaultPageSize > 0) {
+      options.add(Math.floor(descriptor.defaultPageSize));
+    }
+
+    if (options.size === 0) {
+      [10, 25, 50].forEach((option) => options.add(option));
+    }
+
+    return Array.from(options).sort((a, b) => a - b);
+  }, [descriptor.defaultPageSize, descriptor.pageSizeOptions, enablePagination]);
+
+  const defaultPageSize = React.useMemo(() => {
+    if (!enablePagination) {
+      return descriptor.rows.length;
+    }
+
+    const fallback = descriptor.defaultPageSize ?? pageSizeOptions[0] ?? 10;
+    return pageSizeOptions.includes(fallback) ? fallback : pageSizeOptions[0] ?? fallback;
+  }, [descriptor.defaultPageSize, descriptor.rows.length, enablePagination, pageSizeOptions]);
+
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const [pageSize, setPageSize] = React.useState(defaultPageSize);
+  const [page, setPage] = React.useState(1);
+
+  React.useEffect(() => {
+    setSearchTerm('');
+    setPage(1);
+  }, [descriptor.id]);
+
+  React.useEffect(() => {
+    setPageSize(defaultPageSize);
+    setPage(1);
+  }, [defaultPageSize]);
+
+  const filteredRows = React.useMemo(() => {
+    if (!enableSearch) {
+      return descriptor.rows;
+    }
+
+    const term = searchTerm.trim().toLowerCase();
+    if (term.length === 0) {
+      return descriptor.rows;
+    }
+
+    return descriptor.rows.filter((row) =>
+      descriptor.columns.some((column) => {
+        const value = row[column.id];
+        if (value === null || value === undefined) {
+          return false;
+        }
+        return String(value).toLowerCase().includes(term);
+      }),
+    );
+  }, [descriptor.columns, descriptor.rows, enableSearch, searchTerm]);
+
+  const totalItems = filteredRows.length;
+  const totalPages = enablePagination ? Math.max(1, Math.ceil(totalItems / Math.max(pageSize, 1))) : 1;
+  const currentPage = enablePagination ? Math.min(page, totalPages) : 1;
+  const startIndex = enablePagination ? (currentPage - 1) * pageSize : 0;
+  const endIndex = enablePagination ? Math.min(startIndex + pageSize, totalItems) : totalItems;
+  const visibleRows = enablePagination ? filteredRows.slice(startIndex, endIndex) : filteredRows;
+
+  React.useEffect(() => {
+    if (!enablePagination) {
+      return;
+    }
+
+    setPage((prev) => (prev > totalPages ? totalPages : prev));
+  }, [enablePagination, totalPages]);
 
   if (!hasRows) {
     return (
@@ -50,6 +136,83 @@ const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: Report
         {descriptor.description && <p id={descriptionId}>{descriptor.description}</p>}
       </header>
       <div className="reportes-table-card__body">
+        {(enableSearch || enablePagination) && (
+          <div className="reportes-table-controls">
+            {enableSearch && (
+              <div className="reportes-table-controls__search">
+                <label className="sr-only" htmlFor={searchId}>
+                  Buscar en {descriptor.title}
+                </label>
+                <input
+                  id={searchId}
+                  type="search"
+                  className="reportes-table-search"
+                  placeholder={descriptor.searchPlaceholder ?? 'Buscar…'}
+                  value={searchTerm}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    setSearchTerm(event.target.value);
+                    if (enablePagination) {
+                      setPage(1);
+                    }
+                  }}
+                />
+              </div>
+            )}
+            {enablePagination && (
+              <div className="reportes-table-pagination" role="group" aria-label="Paginación de tabla">
+                <div className="reportes-table-pagination__info">
+                  {totalItems === 0
+                    ? 'Sin resultados para mostrar'
+                    : `Mostrando ${startIndex + 1}-${endIndex} de ${totalItems}`}
+                </div>
+                <div className="reportes-table-pagination__actions">
+                  <label className="reportes-table-pagination__page-size">
+                    <span>Filas por página</span>
+                    <select
+                      value={pageSize}
+                      onChange={(event) => {
+                        const nextValue = Number(event.target.value);
+                        if (!Number.isNaN(nextValue)) {
+                          setPageSize(nextValue);
+                          setPage(1);
+                        }
+                      }}
+                    >
+                      {pageSizeOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <div className="reportes-table-pagination__buttons">
+                    <button
+                      type="button"
+                      className="reportes-table-pagination__button"
+                      onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                      disabled={currentPage <= 1}
+                      aria-label="Página anterior"
+                    >
+                      Anterior
+                    </button>
+                    <span className="reportes-table-pagination__page-indicator">
+                      Página {currentPage} de {totalPages}
+                    </span>
+                    <button
+                      type="button"
+                      className="reportes-table-pagination__button"
+                      onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                      disabled={currentPage >= totalPages}
+                      aria-label="Página siguiente"
+                    >
+                      Siguiente
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
         <div className="reportes-table-wrapper">
           <table
             className="reportes-table"
@@ -71,26 +234,34 @@ const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: Report
               </tr>
             </thead>
             <tbody>
-              {descriptor.rows.map((row, index) => (
-                <tr key={index}>
-                  {descriptor.columns.map((column) => {
-                    const value = row[column.id];
-                    const isNumeric = column.isNumeric ?? isNumericColumn(value);
-                    const align = column.align ?? (isNumeric ? 'right' : 'left');
-
-                    return (
-                      <td
-                        key={String(column.id)}
-                        className="reportes-table__cell"
-                        data-column={column.label}
-                        style={{ textAlign: align }}
-                      >
-                        {formatCellValue(value)}
-                      </td>
-                    );
-                  })}
+              {filteredRows.length === 0 ? (
+                <tr>
+                  <td colSpan={descriptor.columns.length} className="reportes-table__cell reportes-table__cell--empty">
+                    {descriptor.searchEmptyMessage ?? 'No se encontraron resultados que coincidan con la búsqueda.'}
+                  </td>
                 </tr>
-              ))}
+              ) : (
+                visibleRows.map((row, index) => (
+                  <tr key={index}>
+                    {descriptor.columns.map((column) => {
+                      const value = row[column.id];
+                      const isNumeric = column.isNumeric ?? isNumericColumn(value);
+                      const align = column.align ?? (isNumeric ? 'right' : 'left');
+
+                      return (
+                        <td
+                          key={String(column.id)}
+                          className="reportes-table__cell"
+                          data-column={column.label}
+                          style={{ textAlign: align }}
+                        >
+                          {formatCellValue(value)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))
+              )}
             </tbody>
             {descriptor.totalRow && (
               <tfoot>

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -341,6 +341,121 @@
   gap: 1rem;
 }
 
+.reportes-table-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reportes-table-controls__search {
+  width: 100%;
+}
+
+.reportes-table-search {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid var(--color-outline);
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.reportes-table-search:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.reportes-table-pagination {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.reportes-table-pagination__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.reportes-table-pagination__page-size {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.reportes-table-pagination__page-size select {
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface);
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+.reportes-table-pagination__page-size select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.reportes-table-pagination__buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reportes-table-pagination__button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-outline);
+  background: var(--color-surface);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.reportes-table-pagination__button:hover:not(:disabled) {
+  background: var(--color-primary-container);
+  color: var(--color-on-primary-container);
+  border-color: rgba(37, 99, 235, 0.35);
+}
+
+.reportes-table-pagination__button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reportes-table-pagination__page-indicator {
+  font-size: 0.85rem;
+  color: var(--color-text-tertiary);
+}
+
+@media (min-width: 768px) {
+  .reportes-table-controls {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .reportes-table-controls__search {
+    max-width: 320px;
+  }
+
+  .reportes-table-pagination {
+    align-items: center;
+  }
+}
+
 .reportes-table-wrapper {
   border: 1px solid var(--color-outline);
   border-radius: 12px;
@@ -381,6 +496,12 @@
   vertical-align: middle;
   background: var(--color-surface-alt);
   transition: background-color 0.2s ease;
+}
+
+.reportes-table__cell--empty {
+  text-align: center !important;
+  color: var(--color-text-secondary);
+  font-style: italic;
 }
 
 .reportes-table tbody tr:last-of-type .reportes-table__cell {

--- a/frontend-app/src/modules/reportes/types.ts
+++ b/frontend-app/src/modules/reportes/types.ts
@@ -64,6 +64,12 @@ export interface ReportTableDescriptor<Row extends BaseTableRow = BaseTableRow> 
   subtotalBy?: keyof Row;
   totalRow?: Partial<Row> & { label?: string };
   emptyMessage?: string;
+  enableSearch?: boolean;
+  searchPlaceholder?: string;
+  searchEmptyMessage?: string;
+  enablePagination?: boolean;
+  pageSizeOptions?: number[];
+  defaultPageSize?: number;
 }
 
 export interface ReportSummaryCard {

--- a/frontend-app/src/modules/reportes/utils/normalizers.ts
+++ b/frontend-app/src/modules/reportes/utils/normalizers.ts
@@ -180,6 +180,12 @@ export function normalizeCifResponse(response: unknown): ReportTableDescriptor<{
     ],
     rows,
     emptyMessage: 'No hay datos de CIF para los filtros aplicados.',
+    enableSearch: true,
+    searchPlaceholder: 'Buscar producto o periodo…',
+    searchEmptyMessage: 'No se encontraron coincidencias para la búsqueda aplicada.',
+    enablePagination: true,
+    pageSizeOptions: [5, 10, 25, 50],
+    defaultPageSize: 10,
   };
 }
 


### PR DESCRIPTION
## Summary
- add optional search and pagination settings to the generic report table component
- configure the CIF por producto descriptor to expose filtering, page size, and pagination defaults
- style the new controls to match the reporting module’s visual language

## Testing
- npm install *(fails: 403 Forbidden fetching recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68f2aea57c308330b2a35a56f86a378b