### PR TITLE
Add searchable product selector to cost filters

### DIFF
--- a/frontend-app/src/modules/costos/hooks/useCuadrosProducts.ts
+++ b/frontend-app/src/modules/costos/hooks/useCuadrosProducts.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import apiClient from '@/lib/http/apiClient';
+import { useQuery } from '@/lib/query/QueryClient';
+import { normalizeCuadrosResponse } from '../../reportes/utils/normalizers';
+
+interface UseCuadrosProductsOptions {
+  enabled?: boolean;
+}
+
+export function useCuadrosProducts({ enabled = true }: UseCuadrosProductsOptions = {}) {
+  const query = useQuery<string[]>({
+    queryKey: ['reportes', 'cuadros', 'productos'],
+    enabled,
+    staleTime: 1000 * 60 * 10,
+    queryFn: async () => {
+      const response = await apiClient.get<unknown>('/api/reportes/cuadros');
+      const cards = normalizeCuadrosResponse(response);
+      const unique = new Map<string, string>();
+
+      for (const card of cards) {
+        const candidate = (card.producto ?? '').trim();
+        if (!candidate || candidate === '—') {
+          continue;
+        }
+        const key = candidate.toLocaleLowerCase('es');
+        if (!unique.has(key)) {
+          unique.set(key, candidate);
+        }
+      }
+
+      return Array.from(unique.values()).sort((a, b) =>
+        a.localeCompare(b, 'es', { sensitivity: 'base' }),
+      );
+    },
+  });
+
+  const products = useMemo(
+    () => (query.data ?? []).map((product) => product.trim()).filter((product) => product.length > 0),
+    [query.data],
+  );
+
+  return {
+    products,
+    isLoading: query.status === 'loading' && enabled,
+    error: query.error,
+    refetch: query.refetch,
+    status: query.status,
+  } as const;
+}
+
+export type UseCuadrosProductsReturn = ReturnType<typeof useCuadrosProducts>;


### PR DESCRIPTION
## Summary
- replace the product filter text field with a searchable select backed by the cuadros report data
- add a reusable hook that fetches and normalizes available products from `/api/reportes/cuadros`

## Testing
- `npm test` *(fails: TypeScript cannot find Node type definitions because installing dependencies is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2b055a7d883309d75c5f192432f23