### PR TITLE
Add searchable product selector to CIF forms

### DIFF
--- a/frontend-app/src/modules/cif/CifModule.tsx
+++ b/frontend-app/src/modules/cif/CifModule.tsx
@@ -13,6 +13,8 @@ import type {
   CreateCifTotalPayload,
   CreateCifUnitarioPayload,
 } from './types';
+import { useCuadrosProducts } from '../costos/hooks/useCuadrosProducts';
+import { SearchableSelect } from './components/SearchableSelect';
 import './cif.css';
 
 type CifSection = 'panel' | 'totales' | 'unitarios' | 'recalculo';
@@ -98,6 +100,12 @@ const CifModule: React.FC<CifModuleProps> = ({ activeSection, onSectionChange })
   const [totalStatus, setTotalStatus] = useState<FormStatus>({ state: 'idle', message: null });
   const [unitarioStatus, setUnitarioStatus] = useState<FormStatus>({ state: 'idle', message: null });
   const [recalculoStatus, setRecalculoStatus] = useState<FormStatus>({ state: 'idle', message: null });
+  const {
+    products: productOptions,
+    isLoading: areProductsLoading,
+    status: productsStatus,
+  } = useCuadrosProducts();
+  const showProductsError = productsStatus === 'error';
 
   const handleApplyFilters = useCallback(
     (event?: React.FormEvent<HTMLFormElement>) => {
@@ -151,6 +159,14 @@ const CifModule: React.FC<CifModuleProps> = ({ activeSection, onSectionChange })
   const handleUnitarioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
     setUnitarioForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleTotalProductChange = (value: string) => {
+    setTotalForm((prev) => ({ ...prev, producto: value }));
+  };
+
+  const handleUnitarioProductChange = (value: string) => {
+    setUnitarioForm((prev) => ({ ...prev, producto: value }));
   };
 
   const handleRecalculoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -398,14 +414,21 @@ const CifModule: React.FC<CifModuleProps> = ({ activeSection, onSectionChange })
           <form className="cif-form" onSubmit={handleSubmitTotal}>
             <label className="cif-field">
               <span>Producto</span>
-              <input
-                type="text"
+              <SearchableSelect
                 name="producto"
                 value={totalForm.producto}
-                onChange={handleTotalChange}
+                onChange={handleTotalProductChange}
+                options={productOptions}
+                placeholder="Selecciona un producto"
                 required
+                loading={areProductsLoading}
               />
             </label>
+            {showProductsError && (
+              <p className="cif-status cif-status--error" role="alert">
+                No se pudieron cargar los productos. Intenta recargar la página.
+              </p>
+            )}
             <label className="cif-field">
               <span>Periodo</span>
               <input
@@ -449,12 +472,14 @@ const CifModule: React.FC<CifModuleProps> = ({ activeSection, onSectionChange })
           <form className="cif-form" onSubmit={handleSubmitUnitario}>
             <label className="cif-field">
               <span>Producto</span>
-              <input
-                type="text"
+              <SearchableSelect
                 name="producto"
                 value={unitarioForm.producto}
-                onChange={handleUnitarioChange}
+                onChange={handleUnitarioProductChange}
+                options={productOptions}
+                placeholder="Selecciona un producto"
                 required
+                loading={areProductsLoading}
               />
             </label>
             <label className="cif-field">

--- a/frontend-app/src/modules/cif/cif.css
+++ b/frontend-app/src/modules/cif/cif.css
@@ -151,16 +151,100 @@
   font-size: 0.95rem;
 }
 
-.cif-field input {
+.cif-field input,
+.cif-searchable-select__input {
   border-radius: 0.5rem;
   border: 1px solid #d1d5db;
   padding: 0.5rem 0.75rem;
   font-size: 1rem;
 }
 
-.cif-field input:focus {
+.cif-field input:focus,
+.cif-searchable-select__input:focus {
   outline: 2px solid #2563eb;
   outline-offset: 2px;
+}
+
+.cif-searchable-select {
+  position: relative;
+}
+
+.cif-searchable-select__control {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.cif-searchable-select__input {
+  width: 100%;
+  padding-right: 2.5rem;
+}
+
+.cif-searchable-select__trigger {
+  position: absolute;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+}
+
+.cif-searchable-select__trigger:disabled {
+  cursor: not-allowed;
+  color: #9ca3af;
+}
+
+.cif-searchable-select__list {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  max-height: 14rem;
+  overflow-y: auto;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+  padding: 0.25rem 0;
+  list-style: none;
+  margin: 0;
+}
+
+.cif-searchable-select__option {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.cif-searchable-select__option.is-selected {
+  font-weight: 600;
+  background: #eff6ff;
+}
+
+.cif-searchable-select__option.is-highlighted {
+  background: #dbeafe;
+}
+
+.cif-searchable-select__message {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  padding: 0.75rem;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);
+  font-size: 0.9rem;
+  color: #475569;
 }
 
 .cif-filters__actions {

--- a/frontend-app/src/modules/cif/components/SearchableSelect.tsx
+++ b/frontend-app/src/modules/cif/components/SearchableSelect.tsx
@@ -1,0 +1,273 @@
+import React, {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+export interface SearchableSelectProps {
+  name: string;
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  loading?: boolean;
+  noOptionsText?: string;
+  emptyListText?: string;
+}
+
+export const SearchableSelect: React.FC<SearchableSelectProps> = ({
+  name,
+  value,
+  options,
+  onChange,
+  placeholder,
+  disabled,
+  required,
+  loading = false,
+  noOptionsText = 'Sin coincidencias',
+  emptyListText = 'No hay opciones disponibles',
+}) => {
+  const listId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [inputValue, setInputValue] = useState(value);
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
+
+  const filteredOptions = useMemo(() => {
+    const trimmed = inputValue.trim().toLocaleLowerCase('es');
+    if (!trimmed) {
+      return options;
+    }
+    return options.filter((option) =>
+      option.toLocaleLowerCase('es').includes(trimmed),
+    );
+  }, [inputValue, options]);
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHighlightedIndex(-1);
+      return;
+    }
+
+    if (filteredOptions.length === 0) {
+      setHighlightedIndex(-1);
+      return;
+    }
+
+    setHighlightedIndex((prev) => {
+      if (prev < 0 || prev >= filteredOptions.length) {
+        return 0;
+      }
+      return prev;
+    });
+  }, [filteredOptions, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        setInputValue(value);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, value]);
+
+  const showList = isOpen && !disabled;
+
+  const handleToggle = () => {
+    if (disabled) return;
+    setIsOpen((prev) => !prev);
+    const focusInput = () => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    };
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(focusInput);
+    } else {
+      setTimeout(focusInput, 0);
+    }
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextValue = event.target.value;
+    setInputValue(nextValue);
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+    if (nextValue === '') {
+      onChange('');
+    }
+  };
+
+  const handleOptionSelect = (option: string) => {
+    onChange(option);
+    setInputValue(option);
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!showList) {
+      if (event.key === 'ArrowDown') {
+        setIsOpen(true);
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlightedIndex((prev) => {
+        const next = prev + 1;
+        return next >= filteredOptions.length ? prev : next;
+      });
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlightedIndex((prev) => {
+        const next = prev - 1;
+        return next < 0 ? 0 : next;
+      });
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const option = filteredOptions[highlightedIndex];
+      if (option) {
+        handleOptionSelect(option);
+      } else if (filteredOptions.length === 1) {
+        handleOptionSelect(filteredOptions[0]);
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setIsOpen(false);
+      setInputValue(value);
+    }
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const relatedTarget = event.relatedTarget as Node | null;
+    if (relatedTarget && containerRef.current?.contains(relatedTarget)) {
+      return;
+    }
+    setIsOpen(false);
+    setInputValue(value);
+  };
+
+  const renderList = () => {
+    if (!showList) return null;
+
+    if (loading) {
+      return (
+        <div className="cif-searchable-select__message" role="status">
+          Cargando opciones…
+        </div>
+      );
+    }
+
+    if (options.length === 0) {
+      return (
+        <div className="cif-searchable-select__message" role="status">
+          {emptyListText}
+        </div>
+      );
+    }
+
+    if (filteredOptions.length === 0) {
+      return (
+        <div className="cif-searchable-select__message" role="status">
+          {noOptionsText}
+        </div>
+      );
+    }
+
+    return (
+      <ul
+        className="cif-searchable-select__list"
+        role="listbox"
+        id={listId}
+        data-listbox
+      >
+        {filteredOptions.map((option, index) => {
+          const isSelected = option === value;
+          const isHighlighted = index === highlightedIndex;
+          return (
+            <li
+              key={`${option}-${index}`}
+              role="option"
+              aria-selected={isSelected}
+              className={[
+                'cif-searchable-select__option',
+                isSelected ? 'is-selected' : '',
+                isHighlighted ? 'is-highlighted' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                handleOptionSelect(option);
+              }}
+              onMouseEnter={() => setHighlightedIndex(index)}
+            >
+              {option}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  return (
+    <div className="cif-searchable-select" ref={containerRef}>
+      <div className="cif-searchable-select__control">
+        <input
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          aria-expanded={showList}
+          aria-controls={listId}
+          aria-autocomplete="list"
+          aria-haspopup="listbox"
+          name={name}
+          value={inputValue}
+          onChange={handleInputChange}
+          onFocus={() => !disabled && setIsOpen(true)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="cif-searchable-select__input"
+          autoComplete="off"
+          required={required}
+        />
+        <button
+          type="button"
+          className="cif-searchable-select__trigger"
+          aria-label="Mostrar opciones"
+          onClick={handleToggle}
+          disabled={disabled}
+        >
+          <span aria-hidden>▾</span>
+        </button>
+      </div>
+      {renderList()}
+    </div>
+  );
+};
+
+export default SearchableSelect;


### PR DESCRIPTION
## Summary
- replace the CIF total and unitario product inputs with a searchable select powered by products from the reportes/cuadros service
- add a reusable searchable select component with supporting styles for the CIF module
- show an inline error when the products list cannot be loaded

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68f2b4718e008330a5a4e5a5df52fc72