### PR TITLE
Reubicar la paginación de CIF por producto

### DIFF
--- a/frontend-app/src/modules/reportes/components/ReportTable.tsx
+++ b/frontend-app/src/modules/reportes/components/ReportTable.tsx
@@ -136,81 +136,26 @@ const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: Report
         {descriptor.description && <p id={descriptionId}>{descriptor.description}</p>}
       </header>
       <div className="reportes-table-card__body">
-        {(enableSearch || enablePagination) && (
+        {enableSearch && (
           <div className="reportes-table-controls">
-            {enableSearch && (
-              <div className="reportes-table-controls__search">
-                <label className="sr-only" htmlFor={searchId}>
-                  Buscar en {descriptor.title}
-                </label>
-                <input
-                  id={searchId}
-                  type="search"
-                  className="reportes-table-search"
-                  placeholder={descriptor.searchPlaceholder ?? 'Buscar…'}
-                  value={searchTerm}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setSearchTerm(event.target.value);
-                    if (enablePagination) {
-                      setPage(1);
-                    }
-                  }}
-                />
-              </div>
-            )}
-            {enablePagination && (
-              <div className="reportes-table-pagination" role="group" aria-label="Paginación de tabla">
-                <div className="reportes-table-pagination__info">
-                  {totalItems === 0
-                    ? 'Sin resultados para mostrar'
-                    : `Mostrando ${startIndex + 1}-${endIndex} de ${totalItems}`}
-                </div>
-                <div className="reportes-table-pagination__actions">
-                  <label className="reportes-table-pagination__page-size">
-                    <span>Filas por página</span>
-                    <select
-                      value={pageSize}
-                      onChange={(event) => {
-                        const nextValue = Number(event.target.value);
-                        if (!Number.isNaN(nextValue)) {
-                          setPageSize(nextValue);
-                          setPage(1);
-                        }
-                      }}
-                    >
-                      {pageSizeOptions.map((option) => (
-                        <option key={option} value={option}>
-                          {option}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <div className="reportes-table-pagination__buttons">
-                    <button
-                      type="button"
-                      className="reportes-table-pagination__button"
-                      onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
-                      disabled={currentPage <= 1}
-                      aria-label="Página anterior"
-                    >
-                      Anterior
-                    </button>
-                    <span className="reportes-table-pagination__page-indicator">
-                      Página {currentPage} de {totalPages}
-                    </span>
-                    <button
-                      type="button"
-                      className="reportes-table-pagination__button"
-                      onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
-                      disabled={currentPage >= totalPages}
-                      aria-label="Página siguiente"
-                    >
-                      Siguiente
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
+            <div className="reportes-table-controls__search">
+              <label className="sr-only" htmlFor={searchId}>
+                Buscar en {descriptor.title}
+              </label>
+              <input
+                id={searchId}
+                type="search"
+                className="reportes-table-search"
+                placeholder={descriptor.searchPlaceholder ?? 'Buscar…'}
+                value={searchTerm}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setSearchTerm(event.target.value);
+                  if (enablePagination) {
+                    setPage(1);
+                  }
+                }}
+              />
+            </div>
           </div>
         )}
         <div className="reportes-table-wrapper">
@@ -289,6 +234,59 @@ const ReportTable = <Row extends Record<string, unknown>>({ descriptor }: Report
             )}
           </table>
         </div>
+        {enablePagination && (
+          <div className="reportes-table-pagination" role="group" aria-label="Paginación de tabla">
+            <div className="reportes-table-pagination__info">
+              {totalItems === 0
+                ? 'Sin resultados para mostrar'
+                : `Mostrando ${(startIndex + 1).toLocaleString()}-${endIndex.toLocaleString()} de ${totalItems.toLocaleString()}`}
+            </div>
+            <div className="reportes-table-pagination__actions">
+              <label className="reportes-table-pagination__page-size">
+                <span>Filas por página</span>
+                <select
+                  value={pageSize}
+                  onChange={(event) => {
+                    const nextValue = Number(event.target.value);
+                    if (!Number.isNaN(nextValue)) {
+                      setPageSize(nextValue);
+                      setPage(1);
+                    }
+                  }}
+                >
+                  {pageSizeOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="reportes-table-pagination__buttons">
+                <button
+                  type="button"
+                  className="reportes-table-pagination__button"
+                  onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                  disabled={currentPage <= 1}
+                  aria-label="Página anterior"
+                >
+                  Anterior
+                </button>
+                <span className="reportes-table-pagination__page-indicator">
+                  Página {currentPage} de {totalPages}
+                </span>
+                <button
+                  type="button"
+                  className="reportes-table-pagination__button"
+                  onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                  disabled={currentPage >= totalPages}
+                  aria-label="Página siguiente"
+                >
+                  Siguiente
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/frontend-app/src/modules/reportes/reportes.css
+++ b/frontend-app/src/modules/reportes/reportes.css
@@ -369,24 +369,26 @@
 
 .reportes-table-pagination {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  align-items: flex-start;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
 .reportes-table-pagination__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .reportes-table-pagination__page-size {
   display: inline-flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  align-items: center;
+  gap: 0.5rem;
   font-size: 0.85rem;
   color: var(--color-text-secondary);
 }
@@ -627,6 +629,16 @@
 }
 
 @media (max-width: 768px) {
+  .reportes-table-pagination {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .reportes-table-pagination__actions {
+    justify-content: space-between;
+  }
+
   .reportes-cuadros-pagination {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- mover la paginación de tablas financieras debajo de la grilla para alinearla con "Detalle por producto"
- mostrar los rangos de elementos paginados con formato localizado
- ajustar los estilos responsive de la paginación para mantener la alineación en escritorio y móviles

## Testing
- npm run lint *(falla: falta @eslint/js en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ae78e34c8330a1233cdb2612cc9f