### PR TITLE
fix: evitar recarga remota al filtrar operación diaria

### DIFF
--- a/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
@@ -23,7 +23,7 @@ const schemaMap: Record<OperacionModulo, Schema<OperacionRegistro>> = {
 const OperacionLayout: React.FC = () => {
   const { modulo, setResumen, resumen } = useOperacionContext();
   const config = operacionConfigs[modulo];
-  const { query, runAccionMasiva, resumen: resumenTabla } = useOperacionData();
+  const { query, registros, runAccionMasiva, resumen: resumenTabla } = useOperacionData();
   const schema = schemaMap[modulo];
   const { importar, status, bitacora, reset } = useBulkImport(modulo, schema);
   const { lastEvent, desbloquear, forceInvalidate } = useOperacionSync();
@@ -35,14 +35,14 @@ const OperacionLayout: React.FC = () => {
   const [showProgress, setShowProgress] = useState(false);
 
   useEffect(() => {
-    if (!query.data || query.data.length === 0) return;
-    const first = query.data[0] as OperacionRegistro;
+    if (!registros || registros.length === 0) return;
+    const first = registros[0] as OperacionRegistro;
     setResumen({
       centro: first.centro,
       calculationDate: first.calculationDate,
       responsable: first.responsable ?? 'coordinador.01',
     });
-  }, [query.data, setResumen]);
+  }, [registros, setResumen]);
 
   const handleAccion = (accion: 'aprobar' | 'recalcular' | 'cerrar') => {
     void (async () => {
@@ -68,7 +68,7 @@ const OperacionLayout: React.FC = () => {
     })();
   };
 
-  const totalRegistros = useMemo(() => query.data?.length ?? 0, [query.data]);
+  const totalRegistros = useMemo(() => registros.length, [registros]);
   // const massPanelId = 'operacion-mass-actions-panel';
   // const bulkPanelId = 'operacion-bulk-upload-panel';
   // const progressPanelId = 'operacion-progress-panel';
@@ -85,7 +85,7 @@ const OperacionLayout: React.FC = () => {
       <OperacionFilterBar config={config} />
       <OperacionDataGrid
         config={config}
-        registros={query.data ?? []}
+        registros={registros}
         onSelect={setSelected}
         loading={query.status === 'loading'}
         error={query.error}

--- a/frontend-app/src/modules/operacion/utils/filterRegistros.ts
+++ b/frontend-app/src/modules/operacion/utils/filterRegistros.ts
@@ -1,0 +1,83 @@
+import type { FiltroPersistente, OperacionModulo, OperacionRegistro } from '../types';
+
+function normalizeText(value?: string | null): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed.toLowerCase();
+}
+
+function normalizeDate(value?: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function matchesTextField(registro: OperacionRegistro, key: keyof OperacionRegistro, filtro?: string): boolean {
+  if (!filtro) return true;
+  const expected = normalizeText(filtro);
+  if (!expected) return true;
+  const raw = registro[key];
+  if (typeof raw !== 'string') return false;
+  const actual = normalizeText(raw);
+  if (!actual) return false;
+  return actual.includes(expected);
+}
+
+function matchesCalculationDate(registro: OperacionRegistro, filtros: FiltroPersistente): boolean {
+  const expected = normalizeDate(filtros.calculationDate);
+  if (!expected) return true;
+  const calculationDate = normalizeDate(registro.calculationDate ?? registro.fecha);
+  if (!calculationDate) return false;
+  return calculationDate === expected;
+}
+
+function matchesRango(registro: OperacionRegistro, filtros: FiltroPersistente): boolean {
+  if (!filtros.rango) return true;
+  const fechaRegistro = normalizeDate(registro.fecha);
+  if (!fechaRegistro) return false;
+  const desde = normalizeDate(filtros.rango.desde);
+  const hasta = normalizeDate(filtros.rango.hasta);
+
+  if (desde && fechaRegistro < desde) return false;
+  if (hasta && fechaRegistro > hasta) return false;
+  return true;
+}
+
+function matchesCentro(registro: OperacionRegistro, filtros: FiltroPersistente): boolean {
+  if (!filtros.centro) return true;
+  if (!('centro' in registro)) return false;
+  const actual = normalizeText(registro.centro ?? '');
+  const expected = normalizeText(filtros.centro);
+  if (!expected) return true;
+  return actual === expected;
+}
+
+function matchesProducto(registro: OperacionRegistro, filtros: FiltroPersistente): boolean {
+  if (!filtros.producto) return true;
+  if (!('producto' in registro)) return false;
+  return matchesTextField(registro, 'producto', filtros.producto);
+}
+
+export function filterOperacionRegistros(
+  registros: OperacionRegistro[] | undefined,
+  modulo: OperacionModulo,
+  filtros: FiltroPersistente,
+): OperacionRegistro[] {
+  if (!registros) return [];
+
+  return registros.filter((registro) => {
+    if (!matchesCalculationDate(registro, filtros)) return false;
+    if (!matchesRango(registro, filtros)) return false;
+
+    if (!matchesProducto(registro, filtros)) return false;
+
+    if (modulo === 'producciones' && !matchesCentro(registro, filtros)) {
+      return false;
+    }
+
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- aplicar un filtrado local de los registros de operación diaria para evitar solicitar el servicio en cada cambio de filtro
- ajustar el layout para consumir la lista filtrada y mantener el resumen contextual alineado con la vista
- incorporar un utilitario reutilizable para normalizar y evaluar los filtros disponibles

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f7f8600b908330ad83d22a9018b8c3