### PR TITLE
feat: enable concept filtering on gastos table

### DIFF
--- a/frontend-app/src/modules/costos/components/CostosLayout.tsx
+++ b/frontend-app/src/modules/costos/components/CostosLayout.tsx
@@ -49,23 +49,38 @@ const CostosLayout: React.FC = () => {
   const records = useMemo(() => {
     const baseRecords = (query.data?.items ?? []) as CostosRecordMap[Exclude<CostosSubModulo, 'prorrateo'>][];
 
-    if (effectiveSubmodule !== 'sueldos') {
-      return baseRecords;
+    if (effectiveSubmodule === 'sueldos') {
+      const normalizedSearch = filters.empleadoQuery?.trim().toLocaleLowerCase('es') ?? '';
+
+      if (normalizedSearch === '') {
+        return baseRecords;
+      }
+
+      return baseRecords.filter((record) => {
+        const sueldoRecord = record as CostosRecordMap['sueldos'];
+        const code = String(sueldoRecord.nroEmpleado ?? '').toLocaleLowerCase('es');
+        const name = (sueldoRecord.empleadoNombre ?? '').toLocaleLowerCase('es');
+        return code.includes(normalizedSearch) || name.includes(normalizedSearch);
+      });
     }
 
-    const normalizedSearch = filters.empleadoQuery?.trim().toLocaleLowerCase('es') ?? '';
+    if (effectiveSubmodule === 'gastos') {
+      const normalizedSearch = filters.concepto?.toLocaleLowerCase('es') ?? '';
 
-    if (normalizedSearch === '') {
-      return baseRecords;
+      if (normalizedSearch === '') {
+        return baseRecords;
+      }
+
+      return baseRecords.filter((record) => {
+        const gastoRecord = record as CostosRecordMap['gastos'];
+        const concept = (gastoRecord.concepto ?? '').toLocaleLowerCase('es');
+        const center = gastoRecord.centro.toLocaleLowerCase('es');
+        return concept.includes(normalizedSearch) || center.includes(normalizedSearch);
+      });
     }
 
-    return baseRecords.filter((record) => {
-      const sueldoRecord = record as CostosRecordMap['sueldos'];
-      const code = String(sueldoRecord.nroEmpleado ?? '').toLocaleLowerCase('es');
-      const name = (sueldoRecord.empleadoNombre ?? '').toLocaleLowerCase('es');
-      return code.includes(normalizedSearch) || name.includes(normalizedSearch);
-    });
-  }, [query.data, effectiveSubmodule, filters.empleadoQuery]);
+    return baseRecords;
+  }, [query.data, effectiveSubmodule, filters.empleadoQuery, filters.concepto]);
 
   useEffect(() => {
     if (records.length === 0) {

--- a/frontend-app/src/modules/costos/hooks/useCostosData.ts
+++ b/frontend-app/src/modules/costos/hooks/useCostosData.ts
@@ -10,6 +10,7 @@ import {
 import type {
   AllocationItem,
   BalanceSummaryData,
+  CostosFilters,
   CostosListResponse,
   CostosRecordMap,
   CostosSubModulo,
@@ -54,9 +55,15 @@ export function useCostosData<K extends Exclude<CostosSubModulo, 'prorrateo'>>()
   }, [filters, submodule]);
 
   const queryFilters = useMemo(() => {
-    const { empleadoQuery, ...rest } = effectiveFilters;
-    return rest;
-  }, [effectiveFilters]);
+    const { empleadoQuery, concepto, ...rest } = effectiveFilters;
+    const baseFilters: CostosFilters = { ...rest };
+
+    if (effectiveSubmodule !== 'gastos' && concepto) {
+      baseFilters.concepto = concepto;
+    }
+
+    return baseFilters;
+  }, [effectiveFilters, effectiveSubmodule]);
 
   const query = useQuery<CostosListResponse<CostosRecordMap[K]>>({
     queryKey: ['costos', effectiveSubmodule, queryFilters],


### PR DESCRIPTION
## Summary
- filter the gastos data table by both concepto and centro as the user types in the concept search
- keep gastos queries stable by avoiding server-side concepto filters so client filtering works with existing results

## Testing
- npm run lint *(fails: missing @eslint/js dependency due to restricted install of dev packages)*

------
https://chatgpt.com/codex/tasks/task_e_68f990ce37d483308c382446bf7d2920