### PR TITLE
Fix Netlify publish directory and SPA routing

### DIFF
--- a/frontend-app/.env.example
+++ b/frontend-app/.env.example
@@ -1,4 +1,4 @@
-VITE_API_URL=https://api.example.com
+VITE_API_URL=https://herbal-backend-ts.onrender.com
 VITE_DEFAULT_CALCULATION_DATE=2025-01-01
 VITE_VERSION=0.0.1
 VITE_SENTRY_DSN=

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  base = "frontend-app"
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  VITE_API_URL = "https://herbal-backend-ts.onrender.com"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary
- point the Netlify publish directory to the Vite build output
- add a catch-all redirect so the single page app loads on deep links

## Testing
- npm run build *(fails: npm install cannot download dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6903e64c705c83309a5e0545f92f5060