### PR TITLE
Fix Netlify build command and publish path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "frontend-app"
-  command = "npm run build"
-  publish = "frontend-app/dist"
+  command = "npm cache clean --force && npm ci && npm run build"
+  publish = "dist"
 
 [build.environment]
   VITE_API_URL = "https://herbal-backend-ts.onrender.com"


### PR DESCRIPTION
## Summary
- ensure Netlify install step cleans cache, reinstalls dependencies, and builds in a single command
- correct the publish directory to use the dist folder relative to the frontend app base

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_6904280dee688330ab8ea877a3f2c247