### PR TITLE
Fix Netlify build command path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,6 @@
 [build]
-  base = "frontend-app"
-  command = "npm cache clean --force && npm ci && npm run build"
-  publish = "dist"
+  command = "cd frontend-app && npm cache clean --force && npm ci && npm run build"
+  publish = "frontend-app/dist"
 
 [build.environment]
   VITE_API_URL = "https://herbal-backend-ts.onrender.com"


### PR DESCRIPTION
## Summary
- run the Netlify build from the frontend-app directory to ensure npm uses the correct lockfile
- publish the built site from frontend-app/dist when deploying

## Testing
- not run (network access to npm registry is blocked in this environment)

------
https://chatgpt.com/codex/tasks/task_e_69042a34e9988330b42dbc30f3c18b6d