### PR TITLE
Fix Netlify install integrity for fast-json-stable-stringify

### DIFF
--- a/frontend-app/package-lock.json
+++ b/frontend-app/package-lock.json
@@ -2301,7 +2301,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLARSHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary
- update the lockfile integrity hash for fast-json-stable-stringify to match the current published tarball

## Testing
- npm ci (fails: 403 Forbidden when downloading packages from registry.npmjs.org in the current environment)


------
https://chatgpt.com/codex/tasks/task_e_69042b5735488330b2538783cfcf8842