### PR TITLE
Fix Netlify build command for frontend

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
-  command = "cd frontend-app && npm cache clean --force && npm ci && npm run build"
-  publish = "frontend-app/dist"
+  base = "frontend-app"
+  command = "npm cache clean --force && npm ci && npm run build"
+  publish = "dist"
 
 [build.environment]
   VITE_API_URL = "https://herbal-backend-ts.onrender.com"


### PR DESCRIPTION
## Summary
- set the Netlify base directory to `frontend-app`
- run npm commands without changing directories manually
- publish the built assets from the correct dist folder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69042d660958833093124a91bf6d9dcc