### PR TITLE
Fix Netlify build by switching to npm install

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "frontend-app"
-  command = "npm cache clean --force && npm ci && npm run build"
+  command = "npm cache clean --force && npm install && npm run build"
   publish = "dist"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- update the Netlify build command to use `npm install` instead of `npm ci`
- ensure the build can proceed even when the lockfile is missing newly added dependencies

## Testing
- not run (npm registry access is blocked in the development container)

------
https://chatgpt.com/codex/tasks/task_e_69042e9a48148330a4c086462a8cf99f