### PR TITLE
Fix TypeScript build errors for Netlify deploy

### DIFF
--- a/frontend-app/src/modules/config/ConfigPage.tsx
+++ b/frontend-app/src/modules/config/ConfigPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ConfiguracionModule from '@/modules/configuracion';
+
+const ConfigPage: React.FC = () => {
+  return <ConfiguracionModule />;
+};
+
+export default ConfigPage;

--- a/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ActividadesPage.tsx
@@ -182,14 +182,14 @@ const ActividadesPage: React.FC = () => {
               searchPlaceholder="Buscar por nombre o número"
             />
 
-            {catalog.error && (
+            {catalog.error ? (
               <div className="config-alert" role="alert">
                 <span>No pudimos cargar las actividades. Intenta nuevamente.</span>
                 <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                   Reintentar
                 </button>
               </div>
-            )}
+            ) : null}
 
             <CatalogTable
               rows={actividades}

--- a/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosApoyoPage.tsx
@@ -361,14 +361,14 @@ const CentrosApoyoPage: React.FC = () => {
         </header>
 
         <div className="catalog-card">
-          {catalog.error && (
+          {catalog.error ? (
             <div className="config-alert" role="alert">
               <span>No pudimos cargar los centros de apoyo.</span>
               <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                 Reintentar
               </button>
             </div>
-          )}
+          ) : null}
 
           {isEditing ? (
             <div className="centros-apoyo__edicion">

--- a/frontend-app/src/modules/configuracion/pages/CentrosPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/CentrosPage.tsx
@@ -191,14 +191,14 @@ const CentrosPage: React.FC = () => {
               searchPlaceholder="Buscar por número o nombre"
             />
 
-            {catalog.error && (
+            {catalog.error ? (
               <div className="config-alert" role="alert">
                 <span>No pudimos cargar los centros. Intenta nuevamente.</span>
                 <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                   Reintentar
                 </button>
               </div>
-            )}
+            ) : null}
 
             <CatalogTable
               rows={centros}

--- a/frontend-app/src/modules/configuracion/pages/EmpleadosPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/EmpleadosPage.tsx
@@ -182,14 +182,14 @@ const EmpleadosPage: React.FC = () => {
               searchPlaceholder="Buscar por número o nombre"
             />
 
-            {catalog.error && (
+            {catalog.error ? (
               <div className="config-alert" role="alert">
                 <span>No pudimos cargar los empleados. Intenta nuevamente.</span>
                 <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
                   Reintentar
                 </button>
               </div>
-            )}
+            ) : null}
 
             <CatalogTable
               rows={empleados}

--- a/frontend-app/src/modules/configuracion/pages/ParametrosGeneralesPage.tsx
+++ b/frontend-app/src/modules/configuracion/pages/ParametrosGeneralesPage.tsx
@@ -218,14 +218,14 @@ const ParametrosGeneralesPage: React.FC = () => {
       <div className="catalog-card">
         <CatalogFilterBar value={filters} onChange={setFilters} disabled={catalog.isLoading} />
 
-        {catalog.error && (
+        {catalog.error ? (
           <div className="config-alert" role="alert">
             <span>No pudimos cargar los parámetros. Intenta nuevamente.</span>
             <button type="button" className="ghost config-alert__action" onClick={() => catalog.refetch()}>
               Reintentar
             </button>
           </div>
-        )}
+        ) : null}
 
         <CatalogTable
           rows={filteredItems}

--- a/frontend-app/src/modules/costos/components/CostosDataTable.tsx
+++ b/frontend-app/src/modules/costos/components/CostosDataTable.tsx
@@ -59,9 +59,9 @@ function getCellValue(
   column: ColumnDefinition,
   currency: string,
 ): React.ReactNode {
-  const value = (record as unknown as Record<string, unknown>)[column.key];
+  const value = record[column.key];
   if (column.render) {
-    return column.render(value, record as Record<string, unknown>);
+    return column.render(value, record);
   }
   if (typeof value === 'number') {
     if (column.align === 'right') {

--- a/frontend-app/src/modules/costos/components/RegisterSalaryDialog.tsx
+++ b/frontend-app/src/modules/costos/components/RegisterSalaryDialog.tsx
@@ -125,8 +125,7 @@ const RegisterSalaryDialog: React.FC<RegisterSalaryDialogProps> = ({
       formState.fechaSueldo !== '' &&
       formState.fechaCalculo !== '' &&
       formState.sueldoTotal !== '' &&
-      Number(formState.sueldoTotal) > 0 &&
-      formState.esGastoDelPeriodo !== ''
+      Number(formState.sueldoTotal) > 0
     );
   }, [formState, hasError, isLoading]);
 

--- a/frontend-app/src/modules/costos/pages/config.ts
+++ b/frontend-app/src/modules/costos/pages/config.ts
@@ -1,12 +1,12 @@
 import type { ReactNode } from 'react';
-import type { CostosSubModulo } from '../types';
+import type { BaseCostRecord, CostosSubModulo } from '../types';
 
 export interface ColumnDefinition {
   key: string;
   label: string;
   width?: string;
   align?: 'left' | 'right' | 'center';
-  render?: (value: unknown, record: Record<string, unknown>) => string | number | ReactNode;
+  render?: (value: unknown, record: BaseCostRecord) => string | number | ReactNode;
 }
 
 export interface CostosModuleConfig {

--- a/frontend-app/src/modules/costos/types.ts
+++ b/frontend-app/src/modules/costos/types.ts
@@ -1,6 +1,6 @@
 export type CostosSubModulo = 'gastos' | 'depreciaciones' | 'sueldos' | 'prorrateo';
 
-export interface CostosFilters {
+export interface CostosFilters extends Record<string, unknown> {
   calculationDate: string;
   centro?: string;
   esGastoDelPeriodo?: boolean;
@@ -9,7 +9,7 @@ export interface CostosFilters {
   empleadoQuery?: string;
 }
 
-export interface BaseCostRecord {
+export interface BaseCostRecord extends Record<string, unknown> {
   id: string;
   centro: string;
   calculationDate: string;

--- a/frontend-app/src/modules/home/HomePage.tsx
+++ b/frontend-app/src/modules/home/HomePage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import '@/App.css';
+
+const HomePage: React.FC = () => {
+  return (
+    <div className="app-home" style={{ padding: '2rem' }}>
+      <h1>Suite Herbal ERP</h1>
+      <p>
+        Selecciona un dominio desde la navegación principal para comenzar a trabajar con los módulos de
+        configuración, operación, costos e informes.
+      </p>
+      <p>
+        Esta vista inicial actúa como placeholder para el dashboard principal y asegura que la aplicación pueda
+        cargarse correctamente en entornos de despliegue como Netlify.
+      </p>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/frontend-app/src/modules/operacion/components/OperacionDataGrid.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionDataGrid.tsx
@@ -54,7 +54,7 @@ const OperacionDataGrid: React.FC<Props> = ({ config, registros, onSelect, loadi
   }, [registros, onSelect]);
 
   const renderCell = (registro: OperacionRegistro, key: string) => {
-    const value = (registro as Record<string, unknown>)[key];
+    const value = registro[key];
     if (value === null || value === undefined || value === '') {
       return '—';
     }
@@ -122,7 +122,7 @@ const OperacionDataGrid: React.FC<Props> = ({ config, registros, onSelect, loadi
                     </td>
                   ))}
                   <td className="operacion-datagrid__cell operacion-datagrid__cell--nowrap">
-                    <SyncStatusBadge status={registro.syncStatus}>
+                    <SyncStatusBadge status={registro.syncStatus ?? 'synced'}>
                       {registro.source} · {formatDate(registro.createdAt)}
                     </SyncStatusBadge>
                   </td>

--- a/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
+++ b/frontend-app/src/modules/operacion/components/OperacionLayout.tsx
@@ -38,8 +38,8 @@ const OperacionLayout: React.FC = () => {
     if (!registros || registros.length === 0) return;
     const first = registros[0] as OperacionRegistro;
     setResumen({
-      centro: first.centro,
-      calculationDate: first.calculationDate,
+      centro: first.centro ?? 'Centro sin asignar',
+      calculationDate: first.calculationDate ?? first.fecha,
       responsable: first.responsable ?? 'coordinador.01',
     });
   }, [registros, setResumen]);

--- a/frontend-app/src/modules/operacion/hooks/useOperacionData.ts
+++ b/frontend-app/src/modules/operacion/hooks/useOperacionData.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@/lib/query/QueryClient';
+import type { QueryKey } from '@/lib/query/queryClientCore';
 import { useOperacionContext } from '../context/OperacionContext';
 import {
   createOperacionRegistro,
@@ -20,8 +21,10 @@ import { filterOperacionRegistros } from '../utils/filterRegistros';
 export function useOperacionData() {
   const { modulo, filtros } = useOperacionContext();
   const queryClient = useQueryClient();
+  const baseKey: QueryKey = ['operacion', modulo];
+
   const query = useQuery<OperacionRegistro[]>({
-    queryKey: ['operacion', modulo],
+    queryKey: baseKey,
     queryFn: async () => {
       return fetchOperacionRegistros(modulo, filtros);
     },
@@ -39,7 +42,7 @@ export function useOperacionData() {
     },
     onSuccess: (registro) => {
       emitOperacionEvent({ type: 'registro:creado', modulo, registro });
-      queryClient.invalidateQueries(['operacion', modulo]);
+      queryClient.invalidateQueries(baseKey);
     },
   });
 
@@ -50,7 +53,7 @@ export function useOperacionData() {
     },
     onSuccess: (registro) => {
       emitOperacionEvent({ type: 'registro:actualizado', modulo, registro });
-      queryClient.invalidateQueries(['operacion', modulo]);
+      queryClient.invalidateQueries(baseKey);
     },
   });
 
@@ -61,7 +64,7 @@ export function useOperacionData() {
     },
     onSuccess: (id) => {
       emitOperacionEvent({ type: 'registro:eliminado', modulo, id });
-      queryClient.invalidateQueries(['operacion', modulo]);
+      queryClient.invalidateQueries(baseKey);
     },
   });
 
@@ -72,7 +75,7 @@ export function useOperacionData() {
       if (accion === 'cerrar') {
         emitOperacionEvent({ type: 'cierre:solicitado', modulo, payload: { closeReason: resultado.mensaje } });
       }
-      queryClient.invalidateQueries(['operacion', modulo]);
+      queryClient.invalidateQueries(baseKey);
       return resultado;
     },
     [modulo, queryClient],
@@ -98,7 +101,7 @@ export function useOperacionData() {
 }
 
 export function useImportacionStatus(modulo: OperacionModulo) {
-  const key = ['operacion', modulo, 'import-status'] as const;
+  const key: QueryKey = ['operacion', modulo, 'import-status'];
   const queryClient = useQueryClient();
   const status = (queryClient.getQuery<ImportStatus>(key)?.data ?? 'idle') as ImportStatus;
   const setStatus = (nuevo: ImportStatus) => {

--- a/frontend-app/src/modules/operacion/types.ts
+++ b/frontend-app/src/modules/operacion/types.ts
@@ -16,7 +16,7 @@ export interface TrazabilidadMetadata {
   accessId?: string;
 }
 
-export interface BaseOperacionRegistro extends TrazabilidadMetadata {
+export interface BaseOperacionRegistro extends TrazabilidadMetadata, Record<string, unknown> {
   id: string;
   centro?: string;
   fecha: string;

--- a/frontend-app/src/modules/reportes/api/reportesApi.ts
+++ b/frontend-app/src/modules/reportes/api/reportesApi.ts
@@ -24,6 +24,7 @@ import {
   normalizeDownloadLog,
   normalizeManoObraResponse,
 } from '../utils/normalizers';
+import type { NormalizedCostosResponse } from '../utils/normalizers';
 import { serializeFiltersToSearch } from '../utils/filters';
 
 const endpointMap: Record<ReportId, string> = {
@@ -45,10 +46,10 @@ interface FetchCostosResult {
 export async function fetchCostosReport(filters: ReportFilters): Promise<FetchCostosResult> {
   const query = serializeFiltersToSearch(filters);
   const response = await apiClient.get<unknown>(buildUrl('costos', query));
-  const normalized = normalizeCostosResponse(response);
+  const normalized: NormalizedCostosResponse = normalizeCostosResponse(response);
   const cards = buildCostosSummaryCards(normalized);
 
-  const costosTable: ReportTableDescriptor<{ centro: string; monto: string }> = {
+  const costosTable: ReportTableDescriptor<BaseTableRow> = {
     id: 'costos-centro',
     title: 'Costos por centro',
     description: 'Montos consolidados por centro de costos.',
@@ -56,14 +57,16 @@ export async function fetchCostosReport(filters: ReportFilters): Promise<FetchCo
       { id: 'centro', label: 'Centro', align: 'left' },
       { id: 'monto', label: 'Monto', align: 'right', isNumeric: true },
     ],
-    rows: normalized.costos.map((item) => ({
-      centro: item.centro,
-      monto: new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(item.monto),
-    })),
+    rows: normalized.costos.map((item) =>
+      ({
+        centro: item.centro,
+        monto: new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(item.monto),
+      } satisfies BaseTableRow),
+    ),
     emptyMessage: 'Sin registros de costos para el periodo solicitado.',
   };
 
-  const consumosTable: ReportTableDescriptor<{ producto: string; cantidad: string }> = {
+  const consumosTable: ReportTableDescriptor<BaseTableRow> = {
     id: 'consumos-producto',
     title: 'Consumos por producto',
     description: 'Totales consumidos durante el periodo.',
@@ -71,19 +74,21 @@ export async function fetchCostosReport(filters: ReportFilters): Promise<FetchCo
       { id: 'producto', label: 'Producto' },
       { id: 'cantidad', label: 'Cantidad', align: 'right', isNumeric: true },
     ],
-    rows: normalized.consumos.map((item) => ({
-      producto: item.producto,
-      cantidad: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
-        item.cantidad,
-      ),
-    })),
+    rows: normalized.consumos.map((item) =>
+      ({
+        producto: item.producto,
+        cantidad: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+          item.cantidad,
+        ),
+      } satisfies BaseTableRow),
+    ),
     emptyMessage: 'No se registraron consumos en el periodo seleccionado.',
   };
 
   const cifTable = normalizeCifResponse(normalized.cif);
 
   return {
-    tables: [costosTable, consumosTable, cifTable] as ReportTableDescriptor<BaseTableRow>[],
+    tables: [costosTable, consumosTable, cifTable],
     cards,
   };
 }

--- a/frontend-app/src/modules/reportes/hooks/useReportQuery.ts
+++ b/frontend-app/src/modules/reportes/hooks/useReportQuery.ts
@@ -4,9 +4,11 @@ import type { QueryStatus } from '@/lib/query/queryClientCore';
 import type { ReportFilters, ReportId } from '../types';
 import { useReportesContext } from '../context/ReportesContext';
 
+type QueryKeyComponent = string | number | boolean | null | undefined | Record<string, unknown>;
+
 interface UseReportQueryOptions<TData> {
   reportId: ReportId;
-  queryKeySuffix?: unknown;
+  queryKeySuffix?: QueryKeyComponent;
   fetcher: (filters: ReportFilters) => Promise<TData>;
 }
 
@@ -24,7 +26,13 @@ export function useReportQuery<TData>({
   fetcher,
 }: UseReportQueryOptions<TData>): UseReportQueryResult<TData> {
   const { filters } = useReportesContext();
-  const queryKey = useMemo(() => ['reportes', reportId, filters, queryKeySuffix], [reportId, filters, queryKeySuffix]);
+  const queryKey = useMemo(() => {
+    const base: QueryKeyComponent[] = ['reportes', reportId, filters];
+    if (queryKeySuffix !== undefined) {
+      base.push(queryKeySuffix);
+    }
+    return base;
+  }, [reportId, filters, queryKeySuffix]);
 
   const query = useQuery<TData>({
     queryKey,

--- a/frontend-app/src/modules/reportes/types.ts
+++ b/frontend-app/src/modules/reportes/types.ts
@@ -2,7 +2,7 @@ export type ReportCategory = 'financieros' | 'operativos' | 'auditoria';
 
 export type ReportFormat = 'json' | 'csv' | 'xlsx';
 
-export interface ReportFilters {
+export interface ReportFilters extends Record<string, unknown> {
   periodo?: string;
   producto?: string;
   centro?: string;

--- a/frontend-app/src/modules/reportes/utils/normalizers.ts
+++ b/frontend-app/src/modules/reportes/utils/normalizers.ts
@@ -2,6 +2,7 @@ import { formatCurrency, formatPercentage } from '@/lib/formatters';
 import type {
   ComparisonInsight,
   ComparisonPoint,
+  BaseTableRow,
   ReportCuadroCard,
   ReportDownloadLog,
   ReportFilters,
@@ -18,6 +19,18 @@ interface CostosResponse {
     totalInsumos?: number;
     consistente?: boolean;
     diferencia?: number;
+  };
+}
+
+export interface NormalizedCostosResponse {
+  costos: Array<{ centro: string; monto: number }>;
+  consumos: Array<{ producto: string; cantidad: number }>;
+  cif: Array<{ producto: string; monto: number }>;
+  control: {
+    totalEgresos: number;
+    totalInsumos: number;
+    consistente: boolean;
+    diferencia: number;
   };
 }
 
@@ -66,7 +79,7 @@ interface CuadroResponseItem {
   tendencia?: string;
 }
 
-export function normalizeCostosResponse(response: unknown): Required<CostosResponse> {
+export function normalizeCostosResponse(response: unknown): NormalizedCostosResponse {
   const defaultControl = {
     totalEgresos: 0,
     totalInsumos: 0,
@@ -103,8 +116,8 @@ export function normalizeCostosResponse(response: unknown): Required<CostosRespo
   };
 }
 
-export function buildCostosSummaryCards(response: Required<CostosResponse>): ReportSummaryCard[] {
-  const { totalEgresos, totalInsumos, consistente, diferencia } = response.control;
+export function buildCostosSummaryCards(response: NormalizedCostosResponse): ReportSummaryCard[] {
+  const { totalEgresos = 0, totalInsumos = 0, consistente = false, diferencia = 0 } = response.control;
   const cards: ReportSummaryCard[] = [
     {
       id: 'total-egresos',
@@ -164,13 +177,19 @@ export function buildComparisonInsight(response: unknown): ComparisonInsight {
   };
 }
 
-export function normalizeCifResponse(response: unknown): ReportTableDescriptor<{ producto: string; periodo: string; monto: string }> {
-  const items = Array.isArray(response) ? response : Array.isArray((response as { data?: unknown }).data) ? (response as { data?: unknown[] }).data ?? [] : [];
-  const rows = (items as CifResponseItem[]).map((item) => ({
-    producto: String(item.producto ?? '—'),
-    periodo: item.periodo ? item.periodo.slice(0, 7) : '—',
-    monto: formatCurrency(Number(item.monto ?? 0)),
-  }));
+export function normalizeCifResponse(response: unknown): ReportTableDescriptor<BaseTableRow> {
+  const items = Array.isArray(response)
+    ? response
+    : Array.isArray((response as { data?: unknown }).data)
+      ? (response as { data?: unknown[] }).data ?? []
+      : [];
+  const rows = (items as CifResponseItem[]).map((item) =>
+    ({
+      producto: String(item.producto ?? '—'),
+      periodo: item.periodo ? item.periodo.slice(0, 7) : '—',
+      monto: formatCurrency(Number(item.monto ?? 0)),
+    } satisfies BaseTableRow),
+  );
   return {
     id: 'cif',
     title: 'CIF por producto',
@@ -191,25 +210,22 @@ export function normalizeCifResponse(response: unknown): ReportTableDescriptor<{
   };
 }
 
-export function normalizeConsumosResponse(response: unknown): ReportTableDescriptor<{
-  producto: string;
-  unidad: string;
-  cantidad: string;
-  monto: string;
-}> {
+export function normalizeConsumosResponse(response: unknown): ReportTableDescriptor<BaseTableRow> {
   const items = Array.isArray(response)
     ? response
     : Array.isArray((response as { items?: unknown[] }).items)
       ? (response as { items?: unknown[] }).items ?? []
       : [];
-  const rows = (items as ConsumosResponseItem[]).map((item) => ({
-    producto: String(item.producto ?? '—'),
-    unidad: String(item.unidad ?? '—'),
-    cantidad: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
-      Number(item.cantidad ?? 0),
-    ),
-    monto: formatCurrency(Number(item.monto ?? 0)),
-  }));
+  const rows = (items as ConsumosResponseItem[]).map((item) =>
+    ({
+      producto: String(item.producto ?? '—'),
+      unidad: String(item.unidad ?? '—'),
+      cantidad: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+        Number(item.cantidad ?? 0),
+      ),
+      monto: formatCurrency(Number(item.monto ?? 0)),
+    } satisfies BaseTableRow),
+  );
   return {
     id: 'consumos',
     title: 'Consumos consolidados',
@@ -225,25 +241,22 @@ export function normalizeConsumosResponse(response: unknown): ReportTableDescrip
   };
 }
 
-export function normalizeAsignacionesResponse(response: unknown): ReportTableDescriptor<{
-  centro: string;
-  actividad: string;
-  horas: string;
-  porcentaje: string;
-}> {
+export function normalizeAsignacionesResponse(response: unknown): ReportTableDescriptor<BaseTableRow> {
   const items = Array.isArray(response)
     ? response
     : Array.isArray((response as { data?: unknown[] }).data)
       ? (response as { data?: unknown[] }).data ?? []
       : [];
-  const rows = (items as AsignacionesResponseItem[]).map((item) => ({
-    centro: String(item.centro ?? '—'),
-    actividad: String(item.actividad ?? '—'),
-    horas: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
-      Number(item.horas ?? 0),
-    ),
-    porcentaje: formatPercentage(Number(item.porcentaje ?? 0)),
-  }));
+  const rows = (items as AsignacionesResponseItem[]).map((item) =>
+    ({
+      centro: String(item.centro ?? '—'),
+      actividad: String(item.actividad ?? '—'),
+      horas: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+        Number(item.horas ?? 0),
+      ),
+      porcentaje: formatPercentage(Number(item.porcentaje ?? 0)),
+    } satisfies BaseTableRow),
+  );
   return {
     id: 'asignaciones',
     title: 'Asignaciones por centro',
@@ -259,25 +272,22 @@ export function normalizeAsignacionesResponse(response: unknown): ReportTableDes
   };
 }
 
-export function normalizeManoObraResponse(response: unknown): ReportTableDescriptor<{
-  actividad: string;
-  descripcion: string;
-  horas: string;
-  monto: string;
-}> {
+export function normalizeManoObraResponse(response: unknown): ReportTableDescriptor<BaseTableRow> {
   const items = Array.isArray(response)
     ? response
     : Array.isArray((response as { items?: unknown[] }).items)
       ? (response as { items?: unknown[] }).items ?? []
       : [];
-  const rows = (items as ManoObraResponseItem[]).map((item) => ({
-    actividad: String(item.actividad ?? '—'),
-    descripcion: String(item.descripcion ?? '—'),
-    horas: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
-      Number(item.horas ?? 0),
-    ),
-    monto: formatCurrency(Number(item.monto ?? 0)),
-  }));
+  const rows = (items as ManoObraResponseItem[]).map((item) =>
+    ({
+      actividad: String(item.actividad ?? '—'),
+      descripcion: String(item.descripcion ?? '—'),
+      horas: new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+        Number(item.horas ?? 0),
+      ),
+      monto: formatCurrency(Number(item.monto ?? 0)),
+    } satisfies BaseTableRow),
+  );
   return {
     id: 'mano-obra',
     title: 'Mano de obra por actividad',
@@ -342,8 +352,12 @@ export function normalizeCuadrosResponse(response: unknown): ReportCuadroCard[] 
       producto,
       periodoLabel: periodo,
       costoDirecto: formatCurrency(costoDirecto),
-      costoUnitarioKg: item.costoUnitarioKg ? formatCurrency(item.costoUnitarioKg) : undefined,
-      costoUnitarioLt: item.costoUnitarioLt ? formatCurrency(item.costoUnitarioLt) : undefined,
+      costoUnitarioKg: item.costoUnitarioKg
+        ? formatCurrency(Number(item.costoUnitarioKg ?? 0))
+        : undefined,
+      costoUnitarioLt: item.costoUnitarioLt
+        ? formatCurrency(Number(item.costoUnitarioLt ?? 0))
+        : undefined,
       costoIndirecto: formatCurrency(costoIndirecto),
       diferencia: formatCurrency(diferencia),
       diferenciaPorcentaje: formatPercentage(diferenciaPorcentaje),

--- a/frontend-app/src/modules/reports/ReportsPage.tsx
+++ b/frontend-app/src/modules/reports/ReportsPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReportesModule from '@/modules/reportes';
+
+const ReportsPage: React.FC = () => {
+  return <ReportesModule activeCategory="financieros" />;
+};
+
+export default ReportsPage;


### PR DESCRIPTION
## Summary
- add lightweight stub pages for home, configuration, and reports routes so lazy imports resolve during the build
- update configuration catalog views to render errors safely and relax cost/operation data types for query keys
- tighten report normalizers and API helpers to return fully normalized data compatible with strict TypeScript checks

## Testing
- `npm run build` *(fails: registry access to install dependencies is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69043e2cf89c8330adea77189b9e1524