### PR TITLE
Ensure manual refetch bypasses stale caches

### DIFF
--- a/frontend-app/src/lib/query/QueryClient.tsx
+++ b/frontend-app/src/lib/query/QueryClient.tsx
@@ -51,16 +51,18 @@ export function useQuery<TData>(options: QueryOptions<TData>): UseQueryResult<TD
   }, [options.queryFn]);
 
   const fetchLatest = useCallback(
-    () => client.fetchQuery(parsedKey, () => queryFnRef.current()),
+    (options?: { force?: boolean }) => client.fetchQuery(parsedKey, () => queryFnRef.current(), options),
     [client, parsedKey],
   );
+
+  const forceFetchLatest = useCallback(() => fetchLatest({ force: true }), [fetchLatest]);
 
   const [state, setState] = useState<UseQueryResult<TData>>({
     status: 'idle',
     data: undefined,
     error: undefined,
     updatedAt: 0,
-    refetch: fetchLatest,
+    refetch: forceFetchLatest,
   });
 
   useEffect(() => {
@@ -72,7 +74,7 @@ export function useQuery<TData>(options: QueryOptions<TData>): UseQueryResult<TD
           ...prev,
           ...state,
           data: state.data as TData | undefined,
-          refetch: fetchLatest,
+          refetch: forceFetchLatest,
         }));
       },
     });
@@ -85,7 +87,7 @@ export function useQuery<TData>(options: QueryOptions<TData>): UseQueryResult<TD
         data: record.data as TData,
         error: undefined,
         updatedAt: record.updatedAt,
-        refetch: fetchLatest,
+        refetch: forceFetchLatest,
       });
       return unsubscribe;
     }
@@ -100,7 +102,7 @@ export function useQuery<TData>(options: QueryOptions<TData>): UseQueryResult<TD
           data,
           error: undefined,
           updatedAt: Date.now(),
-          refetch: fetchLatest,
+          refetch: forceFetchLatest,
         });
       })
       .catch((error) => {
@@ -110,7 +112,7 @@ export function useQuery<TData>(options: QueryOptions<TData>): UseQueryResult<TD
           data: undefined,
           error,
           updatedAt: Date.now(),
-          refetch: fetchLatest,
+          refetch: forceFetchLatest,
         });
       });
 
@@ -118,13 +120,13 @@ export function useQuery<TData>(options: QueryOptions<TData>): UseQueryResult<TD
       isMounted = false;
       unsubscribe();
     };
-  }, [client, parsedKey, enabled, staleTime, fetchLatest]);
+  }, [client, parsedKey, enabled, staleTime, fetchLatest, forceFetchLatest]);
 
-  const refetchRef = useRef(fetchLatest);
+  const refetchRef = useRef(forceFetchLatest);
 
   useEffect(() => {
-    refetchRef.current = fetchLatest;
-  }, [fetchLatest]);
+    refetchRef.current = forceFetchLatest;
+  }, [forceFetchLatest]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/frontend-app/src/lib/query/queryClientCore.ts
+++ b/frontend-app/src/lib/query/queryClientCore.ts
@@ -64,18 +64,24 @@ export class QueryClient {
     return created;
   }
 
-  async fetchQuery<TData>(key: QueryKey, queryFn: () => Promise<TData>): Promise<TData> {
+  async fetchQuery<TData>(
+    key: QueryKey,
+    queryFn: () => Promise<TData>,
+    options: { force?: boolean } = {},
+  ): Promise<TData> {
     const record = this.ensureQuery<TData>(key);
 
     if (record.status === 'loading' && record.promise) {
       return record.promise;
     }
 
-    const now = Date.now();
-    const staleTime = this.config.staleTime ?? 0;
+    if (!options.force) {
+      const now = Date.now();
+      const staleTime = this.config.staleTime ?? 0;
 
-    if (record.status === 'success' && now - record.updatedAt < staleTime) {
-      return Promise.resolve(record.data as TData);
+      if (record.status === 'success' && now - record.updatedAt < staleTime) {
+        return Promise.resolve(record.data as TData);
+      }
     }
 
     const promise = queryFn()

--- a/frontend-app/src/modules/configuracion/__tests__/configuracion.test.js
+++ b/frontend-app/src/modules/configuracion/__tests__/configuracion.test.js
@@ -100,3 +100,25 @@ test('QueryClient cachea y permite invalidar', async () => {
 
   assert.equal(fetchCount, 2);
 });
+
+test('QueryClient permite forzar un refetch ignorando staleTime', async () => {
+  const client = createQueryClient({ staleTime: 60_000 });
+  let fetchCount = 0;
+
+  const queryFn = async () => {
+    fetchCount += 1;
+    return fetchCount;
+  };
+
+  const first = await client.fetchQuery(['catalogo', 'force'], queryFn);
+  const cached = await client.fetchQuery(['catalogo', 'force'], queryFn);
+
+  assert.equal(fetchCount, 1);
+  assert.equal(first, 1);
+  assert.equal(cached, 1);
+
+  const forced = await client.fetchQuery(['catalogo', 'force'], queryFn, { force: true });
+
+  assert.equal(fetchCount, 2);
+  assert.equal(forced, 2);
+});


### PR DESCRIPTION
## Summary
- add a `force` option to the custom query client fetch to ignore stale cache windows when required
- update `useQuery` so consumers receive a forced refetch function after mutations
- cover the forced refetch behaviour with an additional unit test

## Testing
- npm test *(fails: TypeScript compiler cannot find Node type definitions because dependencies could not be installed; `npm install` returns 403 from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_6905293d92b88330bd59a2e593e4818b